### PR TITLE
core: affinage audit + API client fixes

### DIFF
--- a/mozzarellm/clients/affinage_api_client.py
+++ b/mozzarellm/clients/affinage_api_client.py
@@ -16,12 +16,48 @@ AUDIT_NOTE_COL = "affinage_audit_note"
 REFUSAL_PREFIXES = ("Parse failed", "No mechanistic", "Insufficient")
 
 
+# The API's audit subtypes rendered as plain language, complete against the
+# R1-R10 rulebook (cheeseman-lab/affinage, affinage/audit_rules.py: IDENTITY
+# R1-R4, GROUNDING R5-R8, BEHAVIOR R9-R10). Unknown subtypes fall back to the
+# verbatim value; the API's other fields (tier, uniprot_band, rules_fired,
+# issue) stay machine-side for future policy use.
+_AUDIT_SUBTYPES = {
+    # IDENTITY -- wrong gene, or wrong product of the right gene
+    "corpus_ungrounded": "gene weakly grounded in its cited literature",
+    "alias_collision": "cited literature may belong to a different gene sharing an alias",
+    "cross_species_homonym": "narrative may describe a same-named gene from another species",
+    "paralog": "narrative may describe a different gene (paralog/alias)",
+    "alt_product": "narrative describes an alternative product of this locus",
+    # GROUNDING -- narrative under-extracts or misuses evidence
+    "recall_miss": "narrative missed evidence available in UniProt",
+    "fabrication": "cites a reference not found in the literature",
+    "truncated_citation": "carries a truncated or malformed citation",
+    "uncited_synthesis": "some claims lack citations",
+    # BEHAVIOR -- generation anomaly / failure
+    "memorization_empty_corpus": "asserts findings without supporting literature",
+    "memorization_wrong_corpus": "content not drawn from its cited literature",
+    "model_safety_refusal": "no usable narrative (model refusal)",
+    "parse_failure": "no usable narrative (output could not be parsed)",
+    "unexpected_refusal": "no usable narrative (model declined despite evidence)",
+}
+
+
 def _audit_note(audit_flag) -> str:
-    """One-line note from the API's audit_flag field; '' when unflagged."""
+    """Human-readable one-line note from the API's audit_flag; '' when unflagged.
+
+    Built from the API's own human-facing fields (verdict + subtype), not the
+    rule-coded `issue` string — e.g. "Evidence-grounding concern: some claims
+    lack citations" rather than "R6: ... overlap = 0.00% (n_cited=3, ...)".
+    """
     if not audit_flag:
         return ""
     if isinstance(audit_flag, dict):
-        return str(audit_flag.get("issue") or audit_flag.get("verdict") or "audit-flagged")
+        verdict = str(audit_flag.get("verdict") or "audit-flagged")
+        subtype = audit_flag.get("subtype")
+        if subtype:
+            detail = _AUDIT_SUBTYPES.get(str(subtype), str(subtype))
+            return f"{verdict}: {detail}"
+        return str(audit_flag.get("issue") or verdict)
     return "audit-flagged"
 
 

--- a/mozzarellm/clients/affinage_api_client.py
+++ b/mozzarellm/clients/affinage_api_client.py
@@ -12,7 +12,17 @@ DEFAULT_MAX_RETRIES = 4
 DEFAULT_BACKOFF_TIME = 1.0
 BASE_URL = "https://affinage.wi.mit.edu"
 ANNOTATION_COL = "affinage_functional_annotation"
+AUDIT_NOTE_COL = "affinage_audit_note"
 REFUSAL_PREFIXES = ("Parse failed", "No mechanistic", "Insufficient")
+
+
+def _audit_note(audit_flag) -> str:
+    """One-line note from the API's audit_flag field; '' when unflagged."""
+    if not audit_flag:
+        return ""
+    if isinstance(audit_flag, dict):
+        return str(audit_flag.get("issue") or audit_flag.get("verdict") or "audit-flagged")
+    return "audit-flagged"
 
 
 class AffinageClient:
@@ -38,7 +48,7 @@ class AffinageClient:
         self.max_retries = max_retries
         self.backoff = backoff_time
         self._session = requests.Session()
-        self._cache: dict[str, str | None] = {}
+        self._cache: dict[str, dict | None] = {}
 
     def _get(self, path: str) -> dict | None:
         """Fetch JSON from the API.
@@ -65,23 +75,23 @@ class AffinageClient:
                     raise last_error from None
         raise RuntimeError("Affinage request failed")
 
-    def get_annotation(self, symbol: str) -> str | None:
-        """Usable mechanistic narrative for a gene, or None if flagged/refused/missing.
+    def get_annotation_record(self, symbol: str) -> dict | None:
+        """Annotation record for a gene, or None if no usable narrative.
 
-        Soft failures (not in DB, audit-flagged, refusal-prefix narrative, empty
-        narrative) emit a warning and return None. Infrastructure failures
-        propagate from `_get` as exceptions.
+        Returns {"narrative": str, "audit_note": str}. Audit-flagged narratives
+        are surfaced, not dropped — the flag is advisory and carried through as
+        audit_note for downstream weighting. Only genuinely unusable responses
+        (not found, empty, or a refusal-message narrative) return None.
+        Infrastructure failures propagate from `_get` as exceptions.
         """
         sym = str(symbol).strip()
         if sym in self._cache:
             return self._cache[sym]
 
         data = self._get(f"/api/mechanistic_narrative/{sym}")
-        result: str | None = None
+        record: dict | None = None
         if data is None:
             warnings.warn(f"Affinage: gene not found for symbol {sym!r}", stacklevel=2)
-        elif data.get("audit_flag"):
-            warnings.warn(f"Affinage: record audit-flagged for {sym!r}", stacklevel=2)
         else:
             narrative = data.get("mechanistic_narrative")
             if not narrative:
@@ -92,32 +102,48 @@ class AffinageClient:
                     stacklevel=2,
                 )
             else:
-                result = narrative
+                note = _audit_note(data.get("audit_flag"))
+                if note:
+                    warnings.warn(
+                        f"Affinage: audit-flagged narrative for {sym!r} ({note}); surfacing",
+                        stacklevel=2,
+                    )
+                record = {"narrative": narrative, "audit_note": note}
 
-        self._cache[sym] = result
-        return result
+        self._cache[sym] = record
+        return record
+
+    def get_annotation(self, symbol: str) -> str | None:
+        """Mechanistic narrative for a gene, or None if unusable.
+
+        Audit-flagged narratives are returned; the flag is available via
+        get_annotation_record().
+        """
+        record = self.get_annotation_record(symbol)
+        return record["narrative"] if record else None
 
     def fetch_functional_annotations(self, chunk: pd.DataFrame, gene_column: str) -> pd.DataFrame:
-        """Return [gene_column, affinage_functional_annotation] for genes with usable narratives.
+        """Return [gene_column, affinage_functional_annotation, affinage_audit_note].
 
-        Genes lacking a usable narrative are omitted, mirroring UniProtClient's
-        "found only" return shape; the caller merges and fills any backup. Warns
-        with a summary of omitted symbols; raises if no symbol returned a usable
-        narrative (matches UniProt's behavior on a zero-result batch).
+        Rows are the genes with usable narratives, mirroring UniProtClient's
+        "found only" return shape; the caller merges and fills any backup.
+        affinage_audit_note carries the API's audit concern ('' when clean).
+        Warns with a summary of omitted symbols; raises if no symbol returned a
+        usable narrative (matches UniProt's behavior on a zero-result batch).
         """
         symbols = [
             str(s).strip()
             for s in chunk[gene_column].dropna().unique()
             if str(s).strip() and str(s).strip() != "NON_TARGETING_CONTROL"
         ]
-        rows: list[tuple[str, str]] = []
+        rows: list[tuple[str, str, str]] = []
         missing: list[str] = []
         for symbol in symbols:
-            annotation = self.get_annotation(symbol)
-            if annotation is None:
+            record = self.get_annotation_record(symbol)
+            if record is None:
                 missing.append(symbol)
             else:
-                rows.append((symbol, annotation))
+                rows.append((symbol, record["narrative"], record["audit_note"]))
 
         if missing:
             warnings.warn(
@@ -132,4 +158,4 @@ class AffinageClient:
                 f"Symbols queried: {missing[:10]}"
             )
 
-        return pd.DataFrame(rows, columns=[gene_column, ANNOTATION_COL])
+        return pd.DataFrame(rows, columns=[gene_column, ANNOTATION_COL, AUDIT_NOTE_COL])

--- a/mozzarellm/clients/llm_api_clients.py
+++ b/mozzarellm/clients/llm_api_clients.py
@@ -22,6 +22,126 @@ from anthropic.types.messages.batch_create_params import Request
 logger = logging.getLogger(__name__)
 
 
+# Models that reject non-default temperature/top_p/top_k with a 400, per the
+# Anthropic model migration guide:
+# https://platform.claude.com/docs/en/about-claude/models/migration-guide
+# These same models also removed budget_tokens-style extended thinking, so the
+# tuple doubles as the offline fallback for the thinking capability lookup.
+_SAMPLING_LOCKED_MODELS = (
+    "claude-sonnet-5",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-mythos-5",
+)
+
+# Model -> whether type=enabled extended thinking is supported, resolved once per
+# process from the Models API capability tree (offline fallback: the tuple above).
+_THINKING_SUPPORT_CACHE: dict[str, bool] = {}
+
+
+def _model_accepts_sampling_params(model: str) -> bool:
+    """Whether the model accepts non-default temperature/top_p/top_k.
+
+    The models in ``_SAMPLING_LOCKED_MODELS`` reject them with a 400 per the
+    migration guide cited above; every other model accepts them.
+    """
+    return not model.startswith(_SAMPLING_LOCKED_MODELS)
+
+
+def _model_supports_enabled_thinking(model: str, api_key: str | None) -> bool:
+    """Whether the model supports type=enabled extended thinking.
+
+    Looks the model up once per process via the Models API capability tree
+    (``.capabilities["thinking"]["types"]["enabled"]["supported"]``). If the
+    lookup fails (offline, no key), falls back to the documented static tuple:
+    the sampling-locked models also removed budget_tokens-style thinking.
+    """
+    if model in _THINKING_SUPPORT_CACHE:
+        return _THINKING_SUPPORT_CACHE[model]
+    try:
+        info = anthropic.Anthropic(api_key=api_key).models.retrieve(model)
+        supported = bool(info.capabilities["thinking"]["types"]["enabled"]["supported"])
+    except Exception as e:
+        supported = not model.startswith(_SAMPLING_LOCKED_MODELS)
+        logger.warning(
+            "Models API thinking-capability lookup failed for %s (%s); "
+            "using the documented static fallback (supported=%s).",
+            model,
+            e,
+            supported,
+        )
+    _THINKING_SUPPORT_CACHE[model] = supported
+    return supported
+
+
+class AnthropicNoTextError(RuntimeError):
+    """Anthropic returned no usable text block.
+
+    Carries the API's stop_reason plus refusal diagnostics (stop_details
+    category and explanation, request id — the fields Anthropic asks for when
+    reporting a misfired refusal). A safety-classifier refusal is deterministic
+    for a given prompt and therefore not retryable; other empty responses
+    (e.g. the whole max_tokens budget spent on thinking) are stochastic and
+    may succeed on retry.
+    """
+
+    def __init__(
+        self,
+        stop_reason: str | None,
+        input_tokens: int | None,
+        output_tokens: int | None,
+        category: str | None = None,
+        explanation: str | None = None,
+        request_id: str | None = None,
+    ):
+        self.stop_reason = stop_reason
+        self.retryable = stop_reason != "refusal"
+        self.category = category
+        self.explanation = explanation
+        self.request_id = request_id
+        hint = " (safety-classifier refusal)" if stop_reason == "refusal" else ""
+        detail = "".join(
+            f", {name}={value!r}"
+            for name, value in (
+                ("category", category),
+                ("explanation", explanation),
+                ("request_id", request_id),
+            )
+            if value
+        )
+        super().__init__(
+            f"Anthropic returned no text{hint}: stop_reason={stop_reason!r}, "
+            f"input_tokens={input_tokens}, output_tokens={output_tokens}{detail}"
+        )
+
+
+def _extract_anthropic_text(response) -> str:
+    """Join all text blocks from a messages response, tolerating thinking blocks.
+
+    Raises AnthropicNoTextError on a refusal or any response with no text block,
+    rather than blindly indexing content[0].
+    """
+    usage = getattr(response, "usage", None)
+    in_tok = getattr(usage, "input_tokens", None)
+    out_tok = getattr(usage, "output_tokens", None)
+    request_id = getattr(response, "_request_id", None)
+    if response.stop_reason == "refusal":
+        details = getattr(response, "stop_details", None)
+        raise AnthropicNoTextError(
+            response.stop_reason,
+            in_tok,
+            out_tok,
+            category=getattr(details, "category", None),
+            explanation=getattr(details, "explanation", None),
+            request_id=request_id,
+        )
+    texts = [b.text for b in response.content if getattr(b, "type", None) == "text"]
+    if not texts:
+        raise AnthropicNoTextError(response.stop_reason, in_tok, out_tok, request_id=request_id)
+    return "".join(texts)
+
+
 class LLMClientBase(ABC):
     """Abstract base class for LLM providers."""
 
@@ -34,6 +154,7 @@ class LLMClientBase(ABC):
         top_k: int | None = None,
         stop_sequences: list[str] | None = None,
         api_key: str | None = None,
+        thinking: bool | None = None,
     ):
         """
         Initialize LLM provider.
@@ -46,6 +167,8 @@ class LLMClientBase(ABC):
             top_k: Top-K sampling parameter (optional, Claude/Gemini only)
             stop_sequences: List of stop sequences (optional)
             api_key: API key (if None, reads from environment)
+            thinking: Extended-thinking control (Claude only). None = model default,
+                False = disabled, True = enabled with a budget under max_tokens.
         """
         self.model = model
         self.temperature = temperature
@@ -53,6 +176,7 @@ class LLMClientBase(ABC):
         self.top_p = top_p
         self.top_k = top_k
         self.stop_sequences = stop_sequences
+        self.thinking = thinking
         self.api_key = api_key or self._get_api_key_from_env()
         self._validate_api_key()
 
@@ -127,6 +251,9 @@ class LLMClientBase(ABC):
                     f"Attempt {attempt + 1}/{max_retries} failed: {type(e).__name__}: {error_str}"
                 )
                 logger.warning(f"{self.__class__.__name__}: {error_msg}")
+
+                if not getattr(e, "retryable", True):
+                    return None, f"{type(e).__name__}: {e}"
 
                 if attempt < max_retries - 1:
                     wait_time = 2**attempt  # Exponential backoff
@@ -214,7 +341,6 @@ class AnthropicClient(LLMClientBase):
         kwargs = {
             "model": self.model,
             "max_tokens": self.max_tokens,
-            "temperature": self.temperature,
             "system": [
                 {
                     "type": "text",
@@ -243,13 +369,9 @@ class AnthropicClient(LLMClientBase):
             ],
         }
 
-        # Add optional sampling parameters
-        if self.top_p is not None:
-            kwargs["top_p"] = self.top_p
-        if self.top_k is not None:
-            kwargs["top_k"] = self.top_k
-        if self.stop_sequences:
-            kwargs["stop_sequences"] = self.stop_sequences
+        # Add optional sampling + thinking params (omitted for models that reject them)
+        kwargs.update(self._sampling_kwargs())
+        kwargs.update(self._thinking_kwarg())
 
         cluster_request = Request(
             custom_id=f"{cluster_id}_analysis_request",
@@ -273,33 +395,92 @@ class AnthropicClient(LLMClientBase):
         return requests
 
     ### Endpoint access functions ###
+    def _resolve_params(self) -> None:
+        """Decide once which sampling and thinking params are actually sent.
+
+        Lazy (first request, never in __init__, so tests and dry-runs stay
+        offline) and cached. Records the outcome in ``self.resolved_params``
+        ({"sent": {...}, "dropped": [...], "thinking": "enabled"|"disabled"|
+        "omitted"}) so a run manifest can log what was actually sent rather
+        than what was configured.
+        """
+        if getattr(self, "_params_resolved", False):
+            return
+        configured: dict = {"temperature": self.temperature}
+        if self.top_p is not None:
+            configured["top_p"] = self.top_p
+        if self.top_k is not None:
+            configured["top_k"] = self.top_k
+        if _model_accepts_sampling_params(self.model):
+            sampling, dropped = configured, []
+        else:
+            sampling, dropped = {}, list(configured)
+            logger.warning(
+                "Model %s rejects non-default sampling params (per the migration "
+                "guide); dropping %s.",
+                self.model,
+                ", ".join(dropped),
+            )
+        if self.stop_sequences:  # accepted by every model
+            sampling["stop_sequences"] = self.stop_sequences
+
+        thinking_kwarg: dict = {}
+        thinking_state = "omitted"
+        if self.thinking is False:
+            thinking_kwarg = {"thinking": {"type": "disabled"}}
+            thinking_state = "disabled"
+        elif self.thinking and _model_supports_enabled_thinking(self.model, self.api_key):
+            budget = min(max(1024, min(self.max_tokens // 2, 8000)), self.max_tokens - 1)
+            thinking_kwarg = {"thinking": {"type": "enabled", "budget_tokens": budget}}
+            thinking_state = "enabled"
+        elif self.thinking:
+            logger.warning(
+                "Model %s does not support type=enabled extended thinking; dropping it.",
+                self.model,
+            )
+
+        self._resolved_sampling_kwargs = sampling
+        self._resolved_thinking_kwarg = thinking_kwarg
+        self.resolved_params = {
+            "sent": dict(sampling),
+            "dropped": dropped,
+            "thinking": thinking_state,
+        }
+        self._params_resolved = True
+
+    def _sampling_kwargs(self) -> dict:
+        """Resolved sampling params for the request (resolves on first use)."""
+        self._resolve_params()
+        return dict(self._resolved_sampling_kwargs)
+
+    def _thinking_kwarg(self) -> dict:
+        """Resolved extended-thinking param for the request (resolves on first use)."""
+        self._resolve_params()
+        return dict(self._resolved_thinking_kwarg)
+
+    def _create_message(self, client, base: dict):
+        """messages.create with the resolved sampling and thinking params."""
+        return client.messages.create(**base, **self._sampling_kwargs(), **self._thinking_kwarg())
+
     def _make_api_call(self, system_prompt: str, user_prompt: str) -> str:
         """
         Makes a single request to the Anthropic messages API.
         https://platform.claude.com/docs/en/api/python/messages/create
+
+        Tolerates thinking blocks in the response and raises AnthropicNoTextError
+        on a refusal or any response with no text block.
         """
 
         client = anthropic.Anthropic(api_key=self.api_key)
 
-        # Build kwargs with optional parameters
-        kwargs = {
+        base = {
             "model": self.model,
             "max_tokens": self.max_tokens,
-            "temperature": self.temperature,
             "system": system_prompt,
-            # "thinking": {"type": "enabled"},  # can eventually set a token budget here
             "messages": [{"role": "user", "content": [{"type": "text", "text": user_prompt}]}],
         }
 
-        # Add optional sampling parameters
-        if self.top_p is not None:
-            kwargs["top_p"] = self.top_p
-        if self.top_k is not None:
-            kwargs["top_k"] = self.top_k
-        if self.stop_sequences:
-            kwargs["stop_sequences"] = self.stop_sequences
-
-        response = client.messages.create(**kwargs)
+        response = self._create_message(client, base)
 
         # Store usage for cost tracking by callers
         if hasattr(response, "usage"):
@@ -313,7 +494,7 @@ class AnthropicClient(LLMClientBase):
         else:
             self.last_usage = {}
 
-        return response.content[0].text
+        return _extract_anthropic_text(response)
 
     def _make_batch_api_call(
         self,
@@ -897,6 +1078,7 @@ def create_client(
     top_k: int | None = None,
     stop_sequences: list[str] | None = None,
     api_key: str | None = None,
+    thinking: bool | None = None,
 ):
     """
     Factory function to create the appropriate client based on model name.
@@ -909,6 +1091,7 @@ def create_client(
         top_k: Top-K sampling parameter (optional, Claude/Gemini only)
         stop_sequences: List of stop sequences (optional)
         api_key: Optional API key (reads from env if None)
+        thinking: Extended-thinking control (Claude only; None/False/True)
 
     Returns:
         Appropriate LLMProvider instance
@@ -925,7 +1108,7 @@ def create_client(
     # Anthropic models
     elif model_lower.startswith("claude"):
         return AnthropicClient(
-            model, temperature, max_tokens, top_p, top_k, stop_sequences, api_key
+            model, temperature, max_tokens, top_p, top_k, stop_sequences, api_key, thinking
         )
 
     # Google models

--- a/mozzarellm/pipeline/bundle_builder.py
+++ b/mozzarellm/pipeline/bundle_builder.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pandas as pd
 
 from mozzarellm.clients.affinage_api_client import ANNOTATION_COL as AFFINAGE_COL
+from mozzarellm.clients.affinage_api_client import AUDIT_NOTE_COL as AFFINAGE_AUDIT_COL
 from mozzarellm.clients.affinage_api_client import AffinageClient
 from mozzarellm.clients.uniprot_api_client import UniProtClient
 from mozzarellm.utils.cluster_utils import cluster_chunker, compute_feature_coherence
@@ -272,7 +273,7 @@ def build_evidence_bundles(
         # for affinage/both, drop the empty backup-source key so each gene shows only its source
         if source in ("affinage", "both"):
             for gene in cluster_as_json:
-                for col in ("UniProt_functional_annotation", AFFINAGE_COL):
+                for col in ("UniProt_functional_annotation", AFFINAGE_COL, AFFINAGE_AUDIT_COL):
                     if gene.get(col) == "":
                         gene.pop(col, None)
 

--- a/mozzarellm/schemas/bundle_schemas.py
+++ b/mozzarellm/schemas/bundle_schemas.py
@@ -101,6 +101,7 @@ class BundleGene(SemiFlexModel):
     # canonical, per-gene annotations (e.g. Uniprot functional annotations)
     UniProt_functional_annotation: str | None = None
     affinage_functional_annotation: str | None = None
+    affinage_audit_note: str | None = None
 
 
 # Main schema model

--- a/tests/test_affinage_api_client.py
+++ b/tests/test_affinage_api_client.py
@@ -12,6 +12,7 @@ import requests
 
 from mozzarellm.clients.affinage_api_client import (
     ANNOTATION_COL,
+    AUDIT_NOTE_COL,
     AffinageClient,
 )
 
@@ -53,13 +54,13 @@ def test_get_annotation_404_returns_none_and_warns(client):
         assert client.get_annotation("NOTAREALGENE") is None
 
 
-def test_get_annotation_audit_flagged_returns_none_and_warns(client):
+def test_get_annotation_audit_flagged_surfaces_narrative_and_warns(client):
     payload = {"gene": "X", "mechanistic_narrative": "anything", "audit_flag": True}
     with (
         patch.object(client._session, "get", return_value=_mock_response(json_data=payload)),
         pytest.warns(UserWarning, match="audit-flagged"),
     ):
-        assert client.get_annotation("X") is None
+        assert client.get_annotation("X") == "anything"
 
 
 def test_get_annotation_refusal_prefix_returns_none_and_warns(client):
@@ -152,7 +153,7 @@ def test_fetch_functional_annotations_returns_only_usable(client):
         pytest.warns(UserWarning),
     ):
         result = client.fetch_functional_annotations(chunk, GENE_COL)
-    assert list(result.columns) == [GENE_COL, ANNOTATION_COL]
+    assert list(result.columns) == [GENE_COL, ANNOTATION_COL, AUDIT_NOTE_COL]
     assert result[GENE_COL].tolist() == ["TP53"]
 
 

--- a/tests/test_affinage_api_client.py
+++ b/tests/test_affinage_api_client.py
@@ -63,6 +63,38 @@ def test_get_annotation_audit_flagged_surfaces_narrative_and_warns(client):
         assert client.get_annotation("X") == "anything"
 
 
+def test_audit_note_renders_api_human_readable_fields():
+    from mozzarellm.clients.affinage_api_client import _audit_note
+
+    # Real API payload shape: verdict + subtype are the human-facing fields;
+    # the rule-coded `issue` string must NOT be the rendered note.
+    flag = {
+        "gene": "PSMA4",
+        "tier": "GROUNDING",
+        "verdict": "Evidence-grounding concern",
+        "subtype": "uncited_synthesis",
+        "uniprot_band": "medium",
+        "rules_fired": "R6,R8",
+        "issue": "R6: narrative-cited PMIDs vs gene2pubmed overlap = 0.00%; R8: 1/3 claims uncited",
+    }
+    assert _audit_note(flag) == "Evidence-grounding concern: some claims lack citations"
+    assert _audit_note({"verdict": "Identity concern", "subtype": "paralog"}) == (
+        "Identity concern: narrative may describe a different gene (paralog/alias)"
+    )
+    # The map is complete against the R1-R10 rulebook's subtype vocabulary.
+    from mozzarellm.clients.affinage_api_client import _AUDIT_SUBTYPES
+
+    assert len(_AUDIT_SUBTYPES) == 14
+    assert _audit_note({"verdict": "Model-behavior concern", "subtype": "parse_failure"}) == (
+        "Model-behavior concern: no usable narrative (output could not be parsed)"
+    )
+    # Unknown subtype falls back to the verbatim value; no subtype falls back to issue.
+    assert _audit_note({"verdict": "V", "subtype": "new_kind"}) == "V: new_kind"
+    assert _audit_note({"issue": "raw detail"}) == "raw detail"
+    assert _audit_note(True) == "audit-flagged"
+    assert _audit_note(None) == ""
+
+
 def test_get_annotation_refusal_prefix_returns_none_and_warns(client):
     payload = {"gene": "X", "mechanistic_narrative": "Insufficient data to build a narrative."}
     with (

--- a/tests/test_llm_api_clients.py
+++ b/tests/test_llm_api_clients.py
@@ -1,0 +1,81 @@
+"""Tests for Anthropic client behavior on newer models: structured
+empty-response errors and upfront parameter resolution."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import mozzarellm.clients.llm_api_clients as llm
+from mozzarellm.clients.llm_api_clients import (
+    AnthropicClient,
+    AnthropicNoTextError,
+    _extract_anthropic_text,
+)
+
+
+def _response(stop_reason, texts=(), thinking=(), stop_details=None):
+    content = [SimpleNamespace(type="thinking", thinking=t) for t in thinking]
+    content += [SimpleNamespace(type="text", text=t) for t in texts]
+    return SimpleNamespace(
+        stop_reason=stop_reason,
+        content=content,
+        usage=SimpleNamespace(input_tokens=10, output_tokens=len(texts)),
+        stop_details=stop_details,
+        _request_id="req_test",
+    )
+
+
+def test_text_blocks_joined_and_thinking_tolerated():
+    resp = _response("end_turn", texts=("part one, ", "part two"), thinking=("hidden",))
+    assert _extract_anthropic_text(resp) == "part one, part two"
+
+
+def test_refusal_not_retryable_and_carries_diagnostics():
+    details = SimpleNamespace(category="cyber", explanation="declined")
+    with pytest.raises(AnthropicNoTextError) as excinfo:
+        _extract_anthropic_text(_response("refusal", stop_details=details))
+    err = excinfo.value
+    assert err.retryable is False
+    assert (err.category, err.explanation, err.request_id) == ("cyber", "declined", "req_test")
+    assert "refusal" in str(err)
+
+
+def test_empty_non_refusal_is_retryable():
+    # e.g. the whole max_tokens budget spent on thinking: stochastic, so a
+    # retry can succeed -- unlike a deterministic refusal.
+    with pytest.raises(AnthropicNoTextError) as excinfo:
+        _extract_anthropic_text(_response("max_tokens", thinking=("only thinking",)))
+    assert excinfo.value.retryable is True
+
+
+def _client(model, **kw):
+    return AnthropicClient(model=model, api_key="test-key", **kw)
+
+
+def test_sampling_dropped_on_locked_model():
+    c = _client("claude-sonnet-5", temperature=0.2)
+    assert "temperature" not in c._sampling_kwargs()
+    assert c.resolved_params["dropped"] == ["temperature"]
+
+
+def test_sampling_kept_on_older_model():
+    c = _client("claude-sonnet-4-5", temperature=0.2)
+    assert c._sampling_kwargs()["temperature"] == 0.2
+    assert c.resolved_params["dropped"] == []
+
+
+def test_thinking_respects_capability_lookup():
+    with patch.object(llm, "_model_supports_enabled_thinking", return_value=False):
+        assert _client("claude-sonnet-5", thinking=True)._thinking_kwarg() == {}
+    with patch.object(llm, "_model_supports_enabled_thinking", return_value=True):
+        kwarg = _client("claude-sonnet-4-5", thinking=True)._thinking_kwarg()
+    assert kwarg["thinking"]["type"] == "enabled"
+
+
+def test_capability_lookup_falls_back_offline():
+    llm._THINKING_SUPPORT_CACHE.clear()
+    with patch.object(llm.anthropic, "Anthropic", side_effect=RuntimeError("offline")):
+        assert llm._model_supports_enabled_thinking("claude-sonnet-5", None) is False
+        assert llm._model_supports_enabled_thinking("claude-sonnet-4-5", None) is True
+    llm._THINKING_SUPPORT_CACHE.clear()


### PR DESCRIPTION
## What this is

Affinage audit-flag surfacing plus the Anthropic client fixes for newer models. Reworked after round-1 review — the prompt-floor edits moved to #26 (the prompts PR), so this PR is only the affinage + API-client slice.

Three commits, +398/−52:
- `ef1bb88` — surface affinage audit flags instead of dropping flagged annotations
- `01e80e5` — structured empty-response errors + upfront parameter resolution
- `72ac3f5` — render affinage audit notes from the API's human-readable fields

## Changes in response to review

- **Parameter handling redesigned as preflight** (was: catch a 400 and string-match undocumented error text, silently retry without the param). Sampling-param support now comes from the documented model migration guide (static table, doc cited in-code); `thinking` support is looked up once per model from the Models API capability tree, cached, with the documented table as offline fallback. No error-message parsing remains anywhere.
- **Recorded config can't lie**: parameters are decided before the first request and exposed as `resolved_params`; dropped params log a warning. (#28 writes this into the run manifest.)
- **`retryable` keyed on `stop_reason`** — False only for a deterministic `refusal`; a transient empty response (e.g. max_tokens spent entirely on thinking) retries.
- **Refusal diagnostics captured**: `stop_details.category`, `.explanation`, and the request id.
- **Audit notes made human-readable** (follow-up to the `:83` thread): notes render from the API's `verdict` + `subtype` fields ("Evidence-grounding concern: some claims lack citations") instead of the rule-coded `issue` string; the subtype map is complete against the R1–R10 rulebook (14 subtypes) with verbatim fallback.
- **Tests in-PR**: `tests/test_llm_api_clients.py` + extended affinage tests exercise the refusal, parameter, and audit-rendering paths offline.

## Validation

Full suite at this tip: 388 passed. Param resolution verified once against the live Models API during development (sonnet-5 reports `enabled` thinking unsupported); audit-flag structure verified against the live Affinage API (`/api/audit/{symbol}`) and the rulebook; tests run fully offline.
