### PR TITLE
prompts: LITB variant + feature gate + output floor

### DIFF
--- a/mozzarellm/clients/llm_api_clients.py
+++ b/mozzarellm/clients/llm_api_clients.py
@@ -331,9 +331,17 @@ class AnthropicClient(LLMClientBase):
 
     ### Helper functions for batch requests ###
     def _make_single_cluster_message_request(
-        self, cluster_id: str, path_to_evidence_bundle: str, system_prompt: str
+        self,
+        cluster_id: str,
+        path_to_evidence_bundle: str,
+        system_prompt: str,
+        include_features: bool = False,
     ) -> Request:
+        from mozzarellm.utils.prompt_factory import strip_feature_fields
+
         bundle_obj = json.loads(Path(path_to_evidence_bundle).read_text(encoding="utf-8"))
+        if not include_features:
+            strip_feature_fields(bundle_obj)  # no feature-interp component => no feature leak
         bundle_text = json.dumps(
             bundle_obj, ensure_ascii=False
         )  # minify JSON; has no effect on readability for LLMs + saves tokens
@@ -380,7 +388,10 @@ class AnthropicClient(LLMClientBase):
         return cluster_request
 
     def _make_list_of_cluster_request_objs(
-        self, cluster_to_prompt_map: dict[str, str], system_prompt: str
+        self,
+        cluster_to_prompt_map: dict[str, str],
+        system_prompt: str,
+        include_features: bool = False,
     ) -> list[str]:
         """
         Returns a list of Request objects for the Anthropic batch messages API.
@@ -388,7 +399,7 @@ class AnthropicClient(LLMClientBase):
         requests = [
             # NOTE: user_prompt is unique to the cluster
             self._make_single_cluster_message_request(
-                cluster_id, path_to_evidence_bundle, system_prompt
+                cluster_id, path_to_evidence_bundle, system_prompt, include_features
             )
             for cluster_id, path_to_evidence_bundle in cluster_to_prompt_map.items()
         ]
@@ -568,8 +579,15 @@ class AnthropicClient(LLMClientBase):
         batch: bool = False,
         screen_name: str | None = None,
         max_retries: int = 3,
+        include_features: bool = False,
     ) -> tuple[dict | None, dict]:
         """Single entry point for cluster analysis.
+
+        include_features keeps per-gene screen features (up/down features,
+        phenotypic strength) in batch evidence bundles; by default they are
+        stripped so runs without a feature-interpretation prompt component
+        never leak features into the prompt. Per-request, not client state,
+        so one client can serve both kinds of requests.
 
         Routes on (mode, mcp, batch) — always returns (parsed, raw_outputs):
 
@@ -598,6 +616,7 @@ class AnthropicClient(LLMClientBase):
                 system_prompt=system_prompt,
                 cluster_to_prompt_map=cluster_to_prompt_map,
                 screen_name=screen_name,
+                include_features=include_features,
             )
 
         if user_prompt is None:
@@ -966,12 +985,15 @@ class AnthropicClient(LLMClientBase):
         system_prompt: str,
         cluster_to_prompt_map: dict[str, str],
         screen_name: str,
+        include_features: bool = False,
     ) -> tuple[None, dict]:
         """Submit + poll + retrieve a message batch. Per-cluster results write
         to disk; returns (None, raw_outputs) where raw_outputs carries batch_id
         and any errored custom_ids."""
         client = anthropic.Anthropic(api_key=self.api_key)
-        request_list = self._make_list_of_cluster_request_objs(cluster_to_prompt_map, system_prompt)
+        request_list = self._make_list_of_cluster_request_objs(
+            cluster_to_prompt_map, system_prompt, include_features
+        )
         message_batch = client.messages.batches.create(requests=request_list)
         batch_id = message_batch.id
 

--- a/mozzarellm/prompt_components.py
+++ b/mozzarellm/prompt_components.py
@@ -159,8 +159,10 @@ Provide a concise analysis in this exact JSON format:
 """
 
 # =============================================================================
-# LITERATURE VALIDATION (mode-agnostic MCP step)
-# Used in single_mcp / cot_mcp / stepwise_mcp — exactly 2 MCP tool calls.
+# LITERATURE VALIDATION (mode-agnostic MCP step) — two selectable variants:
+#   "LIT"  STEP_LITERATURE_VALIDATION    — category-gated (NOVEL_ROLE/UNCHARACTERIZED genes)
+#   "LITB" STEP_LITERATURE_GAPFILL_BLANK — evidence-gated (blank-annotation genes only)
+# Both used in single_mcp / cot_mcp / stepwise_mcp — exactly 2 MCP tool calls.
 # =============================================================================
 
 LITERATURE_VALIDATION_OUTPUT_FORMAT = """
@@ -199,6 +201,27 @@ In the final output, include:
 {LITERATURE_VALIDATION_OUTPUT_FORMAT}
 - A top-level `literature_informed_reclassifications` array listing every gene whose category changed from your pre-literature categorization to post-validation. Each entry: {{"gene": "...", "initial_category": "ESTABLISHED|NOVEL_ROLE|UNCHARACTERIZED", "final_category": "ESTABLISHED|NOVEL_ROLE|UNCHARACTERIZED", "driving_pmids": ["..."], "rationale": "one sentence — what literature justified the move"}}. If nothing changed, use an empty array.
 - A top-level `literature_informed_pathway_revision` object: {{"pre_literature_pathway": "your tentative pathway BEFORE literature validation", "post_literature_pathway": "your final pathway AFTER literature validation (may be the same)", "pathway_changed": true/false, "rationale": "one sentence — what literature drove the change, or why it stayed the same"}}."""
+
+STEP_LITERATURE_GAPFILL_BLANK = """LITERATURE GAP-FILL (evidence-gated MCP):
+Some genes in the evidence bundle have NO functional annotation provided (the annotation field is empty, or absent entirely). For those genes ONLY, use the attached PubMed MCP tools to retrieve functional evidence. Genes that already have annotation text MUST NOT be looked up, regardless of how you classify them.
+
+BEFORE ANY TOOL USE — count the GAP set: genes whose functional-annotation field is empty or absent. This count fixes your ENTIRE tool budget:
+- GAP set EMPTY (zero blank genes) → make ZERO tool calls. Do not search anything at all. Go straight to classification. Most clusters land here.
+- GAP set NON-EMPTY → make EXACTLY TWO tool calls, no more: (1) ONE `search_articles` with all gap genes OR'd together `(GAP1[tiab] OR GAP2[tiab] OR ...)`, max_results=30, [tiab] on every symbol; (2) ONE `get_article_metadata` on the returned PMIDs. Then STOP calling tools permanently.
+
+ABSOLUTE tool rules (violating any of these breaks the run):
+- The 2-call cap is HARD. Never exceed it under any circumstance.
+- Issue the search EXACTLY ONCE. NEVER repeat, re-word, refine, or re-run a search — not even if it returns few results, zero results, or nothing useful. If the search returns nothing for a gene, record "no literature found" for that gene and move on. Re-searching for any reason is FORBIDDEN.
+- NEVER search a gene that already has annotation text — only the blank/GAP genes.
+- Do NOT search per-gene, and do NOT use the tools to explore or brainstorm pathways.
+
+For each GAP gene, extract a one-line functional summary from the retrieved literature, or record "no literature found".
+
+Classify GAP genes on equal footing with the pre-annotated genes using the retrieved evidence: a GAP gene with direct pathway literature → ESTABLISHED/NOVEL_ROLE as warranted; a GAP gene with no retrievable literature → UNCHARACTERIZED (DARK_GENE).
+
+In the final output, add a top-level `mcp_gapfill` array — one entry per GAP gene: {"gene": "...", "evidence_found": true|false, "driving_pmids": ["..."], "retrieved_summary": "..."}. Empty array if there were no GAP genes.
+
+CRITICAL OUTPUT CONSTRAINT: Your entire response MUST be a single valid JSON object and nothing else. Start with `{` and end with `}`. Do NOT write any preamble, plan, or commentary about your searches — no "Based on my analysis...", no "According to PubMed...", no restating of the query. Do NOT write any text before the opening brace or after the closing brace. Report every literature finding ONLY inside JSON fields (rationale, mcp_gapfill), never as prose."""
 
 # =============================================================================
 # FEATURE COHERENCE + PATHWAY CONSISTENCY (feature-interp mode)
@@ -375,6 +398,7 @@ COMPONENT_REGISTRY = {
     "PCC": PATHWAY_CONFIDENCE_CRITERIA,
     "O": OUTPUT_FORMAT_JSON,
     "LIT": STEP_LITERATURE_VALIDATION,
+    "LITB": STEP_LITERATURE_GAPFILL_BLANK,
     "cPH": COT_STEP_PATHWAY_HYPOTHESIS,
     "cGCR": COT_STEP_GENE_CATEGORIZATION,
     "cPri": COT_STEP_SUBCLASSIFICATION,

--- a/mozzarellm/prompt_components.py
+++ b/mozzarellm/prompt_components.py
@@ -132,13 +132,16 @@ are understudied.
 # =============================================================================
 
 OUTPUT_FORMAT_JSON = """
-Provide a concise analysis in this exact JSON format:
+Provide a concise analysis in this exact JSON format. Include every gene, and place each gene in exactly one category between
+ESTABLISHED, NOVEL_ROLE, and UNCHARACTERIZED — never list the same gene in two categories. Only fill the additional fields for
+genes that are in the NOVEL_ROLE or UNCHARACTERIZED categories.
+
 {
   "cluster_id": "[CLUSTER_ID]",  // IMPORTANT: Use the exact cluster_id provided in the prompt
-  "dominant_process": "pathway name (or comma-separated if multiple)",
+  "dominant_process": "pathway name (semicolon-separated if 2-3)",
   "pathway_confidence": "High/Medium/Low",
-  "established_genes": ["GeneA", "GeneB"],
-  "uncharacterized_genes": [
+  "established_genes": ["GeneA", "GeneB"],  // known role in this cluster's dominant process
+  "uncharacterized_genes": [  // little or no functional annotation
     {
       "gene": "GeneC",
       "class": "DARK_GENE | NASCENT | ANNOTATED_ONLY | NON_HUMAN_CHARACTERIZED",
@@ -146,7 +149,7 @@ Provide a concise analysis in this exact JSON format:
       "evidence": "quote(s) from annotations or citations, if available"
     }
   ],
-  "novel_role_genes": [
+  "novel_role_genes": [  // documented function elsewhere, no known role in this process
     {
       "gene": "GeneD",
       "class": "NO_EVIDENCE | INDIRECT_EVIDENCE | PARTIAL_EVIDENCE | CONTRADICTORY_EVIDENCE",

--- a/mozzarellm/utils/prompt_factory.py
+++ b/mozzarellm/utils/prompt_factory.py
@@ -232,11 +232,30 @@ def make_cluster_analysis_system_prompt(
     return prompt
 
 
-def make_single_cluster_analysis_user_prompt(cluster_id, screen_name, cluster_to_bundle_path_map):
+# Screen-derived per-gene feature data plus the aggregate. Stripped from the
+# bundle before it reaches the model unless a feature-interpretation component is
+# active, so features never enter the prompt as uninterpreted noise.
+FEATURE_FIELDS = ("up_features", "down_features", "phenotypic_strength")
+
+
+def strip_feature_fields(bundle_obj: dict) -> None:
+    """Remove screen-derived feature data from an evidence bundle in place."""
+    bundle_obj.pop("feature_coherence", None)
+    for gene in bundle_obj.get("cluster_genes", []):
+        if isinstance(gene, dict):
+            for field in FEATURE_FIELDS:
+                gene.pop(field, None)
+
+
+def make_single_cluster_analysis_user_prompt(
+    cluster_id, screen_name, cluster_to_bundle_path_map, include_features=False
+):
     BUNDLE_PATH = cluster_to_bundle_path_map[str(cluster_id)]
 
     # Build a user prompt from the bundle JSON
     bundle_obj = json.loads(Path(BUNDLE_PATH).read_text(encoding="utf-8"))
+    if not include_features:
+        strip_feature_fields(bundle_obj)  # no feature-interp component => no feature leak
     bundle_text = json.dumps(bundle_obj, ensure_ascii=False)
 
     output_dir = Path(f"output/{screen_name}_analysis/prompts_used/")

--- a/tests/test_prompt_components_registry.py
+++ b/tests/test_prompt_components_registry.py
@@ -11,14 +11,14 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from mozzarellm.prompt_components import (
-    COMPONENT_REGISTRY,
-    CANONICAL_ZERO_SHOT_ORDER,
-    CANONICAL_COT_ORDER,
+from mozzarellm.prompt_components import (  # noqa: E402
     CANONICAL_COT_MCP_ORDER,
+    CANONICAL_COT_ORDER,
+    CANONICAL_ZERO_SHOT_ORDER,
+    COMPONENT_REGISTRY,
     GENE_CATEGORIZATION_RULES,
 )
-from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.arch_bench_routes import (
+from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.arch_bench_routes import (  # noqa: E402
     ROUTE_REGISTRY,
 )
 
@@ -71,6 +71,15 @@ class TestPromptComponentsRegistry:
                 assert "LIT" not in route.component_order, (
                     f"Non-MCP route {route_name!r} should not contain 'LIT'"
                 )
+
+    def test_both_literature_variants_registered(self):
+        # Two selectable MCP literature prompts: category-gated ("LIT") and
+        # blank-annotation gap-fill ("LITB").
+        category = COMPONENT_REGISTRY["LIT"]
+        blank = COMPONENT_REGISTRY["LITB"]
+        assert "NOVEL_ROLE and UNCHARACTERIZED" in category
+        assert "GAP-FILL" in blank and "mcp_gapfill" in blank
+        assert category != blank
 
     def test_feature_interp_orders(self):
         assert "cFC" in COMPONENT_REGISTRY, "cFC (Feature Coherence) should be defined"

--- a/tests/test_prompt_factory_features.py
+++ b/tests/test_prompt_factory_features.py
@@ -1,0 +1,106 @@
+"""Tests for the feature-interpretation gate on the evidence-bundle user prompt.
+
+When no feature-interpretation component is active, screen-derived feature data
+(per-gene up/down features + phenotypic strength, and any aggregate
+feature_coherence) must not reach the model.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from mozzarellm.utils.prompt_factory import (  # noqa: E402
+    make_single_cluster_analysis_user_prompt,
+    strip_feature_fields,
+)
+
+
+def test_strip_feature_fields_removes_features_keeps_annotation():
+    bundle = {
+        "screen_name": "s1",
+        "cluster_id": "1",
+        "feature_coherence": {"features": []},
+        "cluster_genes": [
+            {
+                "gene_symbol": "G1",
+                "up_features": "cell_x; cell_y",
+                "down_features": "nucleus_z",
+                "phenotypic_strength": "4.2",
+                "UniProt_functional_annotation": "does a thing",
+                "accession": "P1",
+            }
+        ],
+    }
+    strip_feature_fields(bundle)
+    assert "feature_coherence" not in bundle
+    g = bundle["cluster_genes"][0]
+    assert "up_features" not in g and "down_features" not in g and "phenotypic_strength" not in g
+    # non-feature evidence is preserved
+    assert g["UniProt_functional_annotation"] == "does a thing"
+    assert g["gene_symbol"] == "G1" and g["accession"] == "P1"
+
+
+def test_user_prompt_gate(tmp_path):
+    bundle = {
+        "screen_name": "s1",
+        "cluster_id": "1",
+        "cluster_genes": [
+            {
+                "gene_symbol": "G1",
+                "up_features": "cell_x; cell_y",
+                "down_features": "nucleus_z",
+                "phenotypic_strength": "4.2",
+                "UniProt_functional_annotation": "does a thing",
+            }
+        ],
+    }
+    bp = tmp_path / "bundle.json"
+    bp.write_text(json.dumps(bundle))
+    m = {"1": bp}
+
+    off = make_single_cluster_analysis_user_prompt("1", "s1", m, include_features=False)
+    on = make_single_cluster_analysis_user_prompt("1", "s1", m, include_features=True)
+
+    for field in ("up_features", "down_features", "phenotypic_strength"):
+        assert field not in off, field
+        assert field in on, field
+    # annotation always present; default (no arg) strips
+    assert "does a thing" in off and "does a thing" in on
+    default = make_single_cluster_analysis_user_prompt("1", "s1", m)
+    assert "up_features" not in default
+
+
+def test_batch_request_gate(tmp_path):
+    # The gate must also hold on the client's batch-request path, where it is a
+    # per-request parameter (default: strip) rather than client state.
+    from mozzarellm.clients.llm_api_clients import AnthropicClient
+
+    bundle = {
+        "screen_name": "s1",
+        "cluster_id": "1",
+        "cluster_genes": [
+            {
+                "gene_symbol": "G1",
+                "up_features": "cell_x; cell_y",
+                "phenotypic_strength": "4.2",
+                "UniProt_functional_annotation": "does a thing",
+            }
+        ],
+    }
+    bp = tmp_path / "bundle.json"
+    bp.write_text(json.dumps(bundle))
+    client = AnthropicClient(model="claude-sonnet-5", api_key="test-key")
+
+    def _bundle_text(request) -> str:
+        return request["params"]["messages"][0]["content"][0]["text"]
+
+    off = client._make_single_cluster_message_request("1", str(bp), "sys")
+    on = client._make_single_cluster_message_request("1", str(bp), "sys", include_features=True)
+    for field in ("up_features", "phenotypic_strength"):
+        assert field not in _bundle_text(off), field
+        assert field in _bundle_text(on), field
+    assert "does a thing" in _bundle_text(off)


### PR DESCRIPTION
## What this is

The prompt-side changes, consolidated after round-1 review: the LITB blank-gene MCP prompt variant, the feature-interpretation gate, and the output floor (moved here from #25 so the prompt discussion lives in one PR).

Three commits, +200/−17:
- `a89c528` LITB — blank-gene MCP prompt as second literature option
- feature gate — screen features stripped from prompts unless a feature-interp component is active; `include_features` is a **per-request** parameter threaded `analyze(...)` → batch request construction (review fix folded in), with a regression test
- output floor — one category per gene + inline category definitions in `OUTPUT_FORMAT_JSON`; the commit message carries the measurements (double-listing 35→7; category definitions recover novel-role recall by removing the authority heuristic)

## Changes in response to review

- **`include_features` bug fixed as prescribed**: per-request, not client state, so one client serves both kinds of requests; `test_batch_request_gate` fails on the old code.
- **Floor relocated here** from #25 per the component-overlap comment — see the floor commit message for why the output contract carries these lines while `GENE_CATEGORIZATION_RULES` keeps categorization guidance.

## Validation
Full suite at this tip: 391 passed; gate covered on both the factory and client batch paths.
