### PR TITLE
benchmark: walkup + mode + order runners

### DIFF
--- a/tests/phase1_prompt_benchmarking/README.md
+++ b/tests/phase1_prompt_benchmarking/README.md
@@ -1,16 +1,17 @@
 # Phase 1 Prompt Benchmarking
 
-Benchmarks MozzareLLM cluster classification against reviewer-consensus ground truth. The benchmark runs as a three-step **pipeline** — `source → walkup → mode` — that decides the evidence source, assembles the prompt, and picks the delivery format. Each step is a runner script: it scores model output against the consensus ground truth and hands its decision to the next step through a small state file. The runners sit on a shared orchestrator engine (routes, config schema, trace parser) documented under **Engine reference** below.
+Benchmarks MozzareLLM cluster classification against reviewer-consensus ground truth. The benchmark runs as a four-step **pipeline** — `source → walkup → mode → order` — that decides the evidence source, assembles the prompt, picks the delivery format, and checks positional sensitivity. Each step is a runner script: it scores model output against the consensus ground truth and hands its decision to the next step through a small state file. The runners sit on a shared orchestrator engine (routes, config schema, trace parser) documented under **Engine reference** below.
 
-## The benchmark pipeline (source → walkup → mode)
+## The benchmark pipeline (source → walkup → mode → order)
 
-The pipeline answers three questions in order, each on the previous step's winner:
+The pipeline answers four questions in order, each on the previous step's winner:
 
 1. **source** — which evidence source (`uniprot` / `affinage` / `both`) gives the best classification recall?
 2. **walkup** — starting from a blank prompt, which framing of each component (CAT → GCR → NPR → UPR → PCC) to adopt, added one at a time?
 3. **mode** — which delivery format (`single_call` / `cot` / `stepwise`) for the final assembled prompt?
+4. **order** — does the component *order* matter? Permute it on the tuned prompt and measure positional sensitivity.
 
-> **Status:** step 1 (`run_source.py`) and the shared evaluator are implemented. Steps 2–3 (`run_walkup.py`, `run_mode.py`) are the next runners; they consume the same evaluator and state envelope described here.
+> **Status:** all four runners (`run_source.py`, `run_walkup.py`, `run_mode.py`, `run_order.py`) and the shared evaluator are implemented; they consume the same evaluator and state envelope described here.
 
 ### 0. Data prep (one-time, upstream of the runners)
 
@@ -42,7 +43,7 @@ python run_source.py --score-only   # re-score existing run dirs, no API
 Each cell is scored by `bench_evaluator` and the source is picked **holistically on coverage-weighted recall** (correct categories / 103 real genes) so a source can't win by dropping hard genes to inflate raw category. The evaluator's diagnostics (per-class precision/recall/F1, per-cluster recall, reviewer source-preference, inter-reviewer concordance) explain *why* a source wins.
 
 - **reads:** `benchmark_bundles/` (master bundles; each run's source view is derived at prompt assembly via `strip_source_fields`), reviewer annotations, `configs/source_{source}.yaml`
-- **writes:** `benchmarking_outputs/source/source_state.json` with `carry = {"source": <winner>}`
+- **writes:** `runs/source/source_state.json` with `carry = {"source": <winner>}`
 
 ### 2. `run_walkup.py` — assemble the prompt (human-gated)
 
@@ -57,14 +58,21 @@ python run_walkup.py --finalize             # assemble the final prompt + render
 ```
 
 - **reads:** `carry.source` (or `--source`, else affinage), the candidate banks in `bench_walkup_candidates.py`
-- **writes:** `benchmarking_outputs/walkup/walkup_state.json` with the carried per-component winning text
+- **writes:** `runs/walkup/walkup_state.json` with the carried per-component winning text
 
 ### 3. `run_mode.py` — pick the delivery format
 
 Runs `{single_call, cot, stepwise}` on the walkup's final assembled prompt (8-slate, n=3) and picks the mode holistically. `single_call` runs the full tuned prompt; `cot`/`stepwise` use different component keys, so they carry only the shared tuned `CAT` lens and keep canonical text elsewhere — a fair mode comparison, not a verbatim transplant.
 
 - **reads:** the walkup carry (source + assembled prompt)
-- **writes:** `benchmarking_outputs/mode/mode_state.json`
+- **writes:** `runs/mode/mode_state.json`
+
+### 4. `run_order.py` — component order (positional sensitivity)
+
+Holds source, mode, and component *content* fixed and permutes the `component_order` across the order variants `[O, O1, O2, O3, O4]` (8-slate, n=3). Picks the order holistically and reports the **cw-recall spread** — how much order alone moves the result. V1 applies order to the `single_call` route with the walkup's assembled texts injected (the keys the walkup tuned); a `cot`/`stepwise` order transplant is out of scope for now.
+
+- **reads:** the mode carry (source + winning mode) + the walkup's component texts
+- **writes:** `runs/order/order_state.json` with the order winner + the cw-recall spread
 
 ### How the steps chain (the state envelope)
 
@@ -116,6 +124,7 @@ phase1_prompt_benchmarking/
     run_source.py                     -- pipeline step 1: pick the evidence source
     run_walkup.py                     -- pipeline step 2: assemble the prompt (human-gated)
     run_mode.py                       -- pipeline step 3: pick the delivery format
+    run_order.py                      -- pipeline step 4: permute component order
     merge_reviewers.py                -- data prep: reviewer annotations -> combined GT table
     build_bundles.py                  -- data prep: benchmark_input.csv -> evidence bundles
 

--- a/tests/phase1_prompt_benchmarking/README.md
+++ b/tests/phase1_prompt_benchmarking/README.md
@@ -43,7 +43,7 @@ python run_source.py --score-only   # re-score existing run dirs, no API
 Each cell is scored by `bench_evaluator` and the source is picked **holistically on coverage-weighted recall** (correct categories / 103 real genes) so a source can't win by dropping hard genes to inflate raw category. The evaluator's diagnostics (per-class precision/recall/F1, per-cluster recall, reviewer source-preference, inter-reviewer concordance) explain *why* a source wins.
 
 - **reads:** `benchmark_bundles/` (master bundles; each run's source view is derived at prompt assembly via `strip_source_fields`), reviewer annotations, `configs/source_{source}.yaml`
-- **writes:** `runs/source/source_state.json` with `carry = {"source": <winner>}`
+- **writes:** `benchmarking_outputs/source/source_state.json` with `carry = {"source": <winner>}`
 
 ### 2. `run_walkup.py` — assemble the prompt (human-gated)
 
@@ -58,21 +58,21 @@ python run_walkup.py --finalize             # assemble the final prompt + render
 ```
 
 - **reads:** `carry.source` (or `--source`, else affinage), the candidate banks in `bench_walkup_candidates.py`
-- **writes:** `runs/walkup/walkup_state.json` with the carried per-component winning text
+- **writes:** `benchmarking_outputs/walkup/walkup_state.json` with the carried per-component winning text
 
 ### 3. `run_mode.py` — pick the delivery format
 
 Runs `{single_call, cot, stepwise}` on the walkup's final assembled prompt (8-slate, n=3) and picks the mode holistically. `single_call` runs the full tuned prompt; `cot`/`stepwise` use different component keys, so they carry only the shared tuned `CAT` lens and keep canonical text elsewhere — a fair mode comparison, not a verbatim transplant.
 
 - **reads:** the walkup carry (source + assembled prompt)
-- **writes:** `runs/mode/mode_state.json`
+- **writes:** `benchmarking_outputs/mode/mode_state.json`
 
 ### 4. `run_order.py` — component order (positional sensitivity)
 
 Holds source, mode, and component *content* fixed and permutes the `component_order` across the order variants `[O, O1, O2, O3, O4]` (8-slate, n=3). Picks the order holistically and reports the **cw-recall spread** — how much order alone moves the result. V1 applies order to the `single_call` route with the walkup's assembled texts injected (the keys the walkup tuned); a `cot`/`stepwise` order transplant is out of scope for now.
 
 - **reads:** the mode carry (source + winning mode) + the walkup's component texts
-- **writes:** `runs/order/order_state.json` with the order winner + the cw-recall spread
+- **writes:** `benchmarking_outputs/order/order_state.json` with the order winner + the cw-recall spread
 
 ### How the steps chain (the state envelope)
 
@@ -156,7 +156,7 @@ phase1_prompt_benchmarking/
     configs/
         source_{uniprot,affinage,both}.yaml   -- one per source (run_source)
 
-    runs/                             -- git submodule (decoupled; nothing overwritten)
+    benchmarking_outputs/             -- git submodule (runs archive here; nothing overwritten)
         source/source_state.json      -- step 1 decision + carry
         walkup/walkup_state.json      -- step 2 assembled prompt + carry
         mode/mode_state.json          -- step 3 decision
@@ -169,19 +169,17 @@ phase1_prompt_benchmarking/
 
 Everything below documents the shared orchestrator the pipeline runners sit on — the route/mode model, per-run output layout, config schema, and trace parser. The `source → walkup → mode → order` runners are the entry points; they build their RunSpecs and drive the orchestrator's run loop directly (there is no separate orchestrator CLI).
 
-## Output structure (`runs/` submodule)
+## Output structure (`benchmarking_outputs/` submodule)
 
-Every runner writes into the decoupled `runs/` submodule under `runs/<step>/`. Each run gets its own **timestamped** directory so nothing is ever overwritten, plus a stable `<step>_state.json` latest-pointer; the whole run is auto-committed and pushed (`bench_pipeline_common.push_run`).
+Every runner writes into the `benchmarking_outputs/` submodule under `benchmarking_outputs/<step>/`. Each run gets its own **timestamped** directory — `<label>_<stamp>/`, where the stamp is baked into the run's `experiment_id` so nothing is ever overwritten — plus a stable `<step>_state.json` latest-pointer that `read_carry` and the figures read.
 
 ```
-runs/
+benchmarking_outputs/
     source/
         source_state.json             -- latest-pointer (read by read_carry / the figures)
-        <stamp>/                      -- one per run, e.g. 20260724_133059
-            source_state.json         -- archived copy of the state for this run
-            <experiment_id>/          -- e.g. affinage / uniprot / both  (or "mode", "order")
-                ...                   -- the per-run outputs below
-    walkup/  mode/  order/            -- same shape, one <step>_state.json + timestamped runs
+        <source>_<stamp>/             -- one archived run per source, e.g. affinage_20260731_101500
+            ...                       -- the per-run outputs below
+    walkup/  mode/  order/            -- same shape: one <step>_state.json + timestamped run dirs
 ```
 
 Each **experiment directory** contains:
@@ -234,7 +232,7 @@ All parameters below are YAML keys. Defaults are shown in parentheses. Parsed by
 - **evidence_bundles_dir** (benchmark_evidence_bundles) -- directory of pre-built evidence bundle JSONs
 
 ----important to adjust as needed----
-- **output_dir** (runs) -- root output directory. The pipeline runners set this to `runs/<step>/<stamp>` automatically; the config value is only a fallback.
+- **output_dir** (benchmarking_outputs) -- root output directory. The pipeline runners point this at `benchmarking_outputs/<step>` and bake a `<stamp>` into experiment_id; the config value is only a fallback.
 
 **model:**
 - **provider** (anthropic) -- LLM provider
@@ -294,7 +292,7 @@ python -m tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.be
 ```
 
 **Parameters:**
-- **--traces-dir** -- path to the `traces/` directory from a benchmark run (e.g. `runs/source/<stamp>/affinage/traces/`)
+- **--traces-dir** -- path to the `traces/` directory from a benchmark run (e.g. `benchmarking_outputs/source/affinage_<stamp>/traces/`)
 - **--output-dir** -- where to write the gene-level CSVs (usually the same directory as the traces)
 - **--experiment-id** -- optional; auto-detected from trace filenames if not provided
 - **--overwrite** -- overwrite existing CSVs; otherwise appends date to filename

--- a/tests/phase1_prompt_benchmarking/README.md
+++ b/tests/phase1_prompt_benchmarking/README.md
@@ -156,31 +156,32 @@ phase1_prompt_benchmarking/
     configs/
         source_{uniprot,affinage,both}.yaml   -- one per source (run_source)
 
-    benchmarking_outputs/             -- git submodule
+    runs/                             -- git submodule (decoupled; nothing overwritten)
         source/source_state.json      -- step 1 decision + carry
         walkup/walkup_state.json      -- step 2 assembled prompt + carry
         mode/mode_state.json          -- step 3 decision
+        order/order_state.json        -- step 4 decision + cw-recall spread
 ```
 
 ---
 
 # Engine reference
 
-Everything below documents the shared orchestrator the pipeline runners sit on — the route/mode model, per-run output layout, config schema, and trace parser. The `source → walkup → mode` runners are the entry points; they build their RunSpecs and drive the orchestrator's run loop directly (there is no separate orchestrator CLI).
+Everything below documents the shared orchestrator the pipeline runners sit on — the route/mode model, per-run output layout, config schema, and trace parser. The `source → walkup → mode → order` runners are the entry points; they build their RunSpecs and drive the orchestrator's run loop directly (there is no separate orchestrator CLI).
 
-## Output Structure (benchmarking_outputs/ Submodule)
+## Output structure (`runs/` submodule)
 
-Outputs are organized by phase, then by experiment. When `workflow_testing: true` in the config, outputs nest under a `_workflow_testing/` subdirectory to keep dev runs separate from final results.
+Every runner writes into the decoupled `runs/` submodule under `runs/<step>/`. Each run gets its own **timestamped** directory so nothing is ever overwritten, plus a stable `<step>_state.json` latest-pointer; the whole run is auto-committed and pushed (`bench_pipeline_common.push_run`).
 
 ```
-benchmarking_outputs/
-    1.arch/
-        _workflow_testing/
-            {experiment_id}/          -- one dir per experiment run
-                ...
-    2.order/
-        {experiment_id}/
-            ...
+runs/
+    source/
+        source_state.json             -- latest-pointer (read by read_carry / the figures)
+        <stamp>/                      -- one per run, e.g. 20260724_133059
+            source_state.json         -- archived copy of the state for this run
+            <experiment_id>/          -- e.g. affinage / uniprot / both  (or "mode", "order")
+                ...                   -- the per-run outputs below
+    walkup/  mode/  order/            -- same shape, one <step>_state.json + timestamped runs
 ```
 
 Each **experiment directory** contains:
@@ -204,7 +205,7 @@ Each **experiment directory** contains:
 - **delivery** -- *single_call* or *multi_turn*. Stepwise routes use multi_turn; standard and cot use single_call.
 - **component_order** -- the ordered tuple of shorthand keys (CAT, SC, GCR, NPR, UPR, PCC, O, cPH, cGCR, cPri, cPSC, cVer, cO, LIT) that defines what goes into the prompt and in what sequence.
 - **variant** -- a named perturbation of component_order relative to the canonical baseline (order axis only). Defined in `bench_order.py`.
-- **base route** -- the route (e.g. 3a, 3b) from which an order variant is derived. The canonical variant preserves the base route's original component_order.
+- **base route** -- the route (e.g. `single_call`) from which an order variant is derived. The canonical variant preserves the base route's original component_order.
 - **replicate** -- repeated execution of the same prompt on the same input. Used to measure reasoning stability at a given temperature.
 
 ## Component libraries (order / wording)
@@ -233,7 +234,7 @@ All parameters below are YAML keys. Defaults are shown in parentheses. Parsed by
 - **evidence_bundles_dir** (benchmark_evidence_bundles) -- directory of pre-built evidence bundle JSONs
 
 ----important to adjust as needed----
-- **output_dir** (benchmarking_outputs/1.arch) -- root output directory. 
+- **output_dir** (runs) -- root output directory. The pipeline runners set this to `runs/<step>/<stamp>` automatically; the config value is only a fallback.
 
 **model:**
 - **provider** (anthropic) -- LLM provider
@@ -253,10 +254,6 @@ All parameters below are YAML keys. Defaults are shown in parentheses. Parsed by
 - **save_raw_outputs** (true) -- write raw_outputs.jsonl
 - **save_parsed_outputs** (true) -- write parsed_outputs.jsonl
 - **save_traces** (true) -- write per-run trace JSONs
-
-
-**routes:** (architecture axis)
-- **include** (all 6) -- list of route names to run: 3a, 3a_mcp, 3b, 3b_mcp, 3c, 3c_mcp. 
 
 **screens:** 
 - **include** ("all" or list) -- which screens to include. Use "all" or a list like `[denali, whitney]`.
@@ -282,11 +279,6 @@ All parameters below are YAML keys. Defaults are shown in parentheses. Parsed by
 - **track_io** (true) -- time writing artifacts
 - **track_step_latencies** (true) -- per-step timing for stepwise routes
 - **track_mcp_tool_latency** (true) -- MCP tool call timing
-
-**order_benchmark:** (order axis)
-- **enabled** (false) -- when true, ignores `routes.include` and instead builds routes from base_routes x variants
-- **base_routes** -- list of route names to permute (e.g. [3a, 3b])
-- **variants** -- list of variant names: canonical, late_screen_context, prioritization_before_classification, early_output_format, delayed_task_anchor
 
 ## Running the Trace Parser
 

--- a/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_figures.py
+++ b/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_figures.py
@@ -454,7 +454,7 @@ def figure_walkup_buildup(state_path: Path, out_png: Path) -> None:
         family="monospace",
     )
     fig.suptitle(
-        "Figure 2 — Build-up prompt walkup (★ = component adopted)",
+        "Figure 2 — Build-up prompt walkup (a star marks each adopted component)",
         fontsize=13,
         fontweight="bold",
     )

--- a/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_figures.py
+++ b/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_figures.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from architecture_benchmarking_workflow.bench_evaluator import MetricPanel
-from architecture_benchmarking_workflow.bench_pipeline_common import metric_value
+from architecture_benchmarking_workflow.bench_pipeline_common import N_REAL_GENES, metric_value
 
 # Colorblind-safe, distinguishable per evidence source; matches the palette
 # used for the same source axis in analysis/make_figures.py.
@@ -32,8 +32,24 @@ _CLASSES = ("ESTABLISHED", "NOVEL_ROLE", "UNCHARACTERIZED")
 _SOURCE_ORDER = ("uniprot", "affinage", "both")
 
 # The per-source metric profile (Fig 1).
-_PROFILE = [("coverage_weighted_category", "cw-recall"), ("category", "category"),
-            ("coverage", "coverage"), ("novel_subclass", "novel"), ("unchar_subclass", "unchar")]
+_PROFILE = [
+    ("coverage_weighted_category", "cw-recall"),
+    ("category", "category"),
+    ("coverage", "coverage"),
+    ("novel_subclass", "novel"),
+    ("unchar_subclass", "unchar"),
+]
+
+# The mode axis (Fig 3): the four consensus-agreement metrics shared across
+# delivery formats (single_call / cot / stepwise).
+METRICS = ["category", "novel_subclass", "unchar_subclass", "coherence"]
+METRIC_LABELS = {
+    "category": "Category",
+    "novel_subclass": "Novel sub-class",
+    "unchar_subclass": "Unchar sub-class",
+    "coherence": "Coherence",
+}
+_MODE_COLORS = {"single_call": "#2E5C8A", "cot": "#B84A3E", "stepwise": "#6E8B3D"}
 
 
 def _setup_style() -> None:
@@ -84,27 +100,56 @@ def figure_reviewer_concordance(state_path: Path, out_png: Path) -> None:
     # A: concordance by level, with sub-class split into UNCHAR (categorical) and NOVEL (ordinal)
     lv, sc = conc["levels"], conc["subclass"]
     un, nv = sc["unchar"], sc["novel"]
-    a_vals = [lv["pathway"]["frac"] * 100, lv["category"]["frac"] * 100,
-              (un["agree"] / un["n"] * 100) if un["n"] else 0.0,
-              (nv["exact"] / nv["n"] * 100) if nv["n"] else 0.0]
-    a_tags = [f'{lv["pathway"]["agree"]}/{lv["pathway"]["n"]}', f'{conc["unanimous"]}/{lv["category"]["n"]}',
-              f'{un["agree"]}/{un["n"]}', f'{nv["exact"]}/{nv["n"]}']
+    a_vals = [
+        lv["pathway"]["frac"] * 100,
+        lv["category"]["frac"] * 100,
+        (un["agree"] / un["n"] * 100) if un["n"] else 0.0,
+        (nv["exact"] / nv["n"] * 100) if nv["n"] else 0.0,
+    ]
+    a_tags = [
+        f"{lv['pathway']['agree']}/{lv['pathway']['n']}",
+        f"{conc['unanimous']}/{lv['category']['n']}",
+        f"{un['agree']}/{un['n']}",
+        f"{nv['exact']}/{nv['n']}",
+    ]
     a_labs = ["Pathway\n(cluster)", "Category\n(gene)", "Sub-class\nUNCHAR", "Sub-class\nNOVEL"]
-    bars = ax_a.bar(range(4), a_vals, color=["#6E8B3D", "#2E5C8A", "#4C9A8A", "#B84A3E"],
-                    edgecolor="white", zorder=2, width=0.66)
+    bars = ax_a.bar(
+        range(4),
+        a_vals,
+        color=["#6E8B3D", "#2E5C8A", "#4C9A8A", "#B84A3E"],
+        edgecolor="white",
+        zorder=2,
+        width=0.66,
+    )
     for b, tag in zip(bars, a_tags, strict=True):
-        ax_a.annotate(f"{b.get_height():.0f}%\n{tag}", (b.get_x() + b.get_width() / 2, b.get_height()),
-                      xytext=(0, 3), textcoords="offset points", ha="center", fontsize=9,
-                      fontweight="bold")
-    ax_a.annotate(f"but {nv['monotone']}/{nv['n']}\nmonotone (ordinal)", (3, a_vals[3]),
-                  xytext=(0, 40), textcoords="offset points", ha="center", fontsize=8,
-                  color="#B84A3E", style="italic")
+        ax_a.annotate(
+            f"{b.get_height():.0f}%\n{tag}",
+            (b.get_x() + b.get_width() / 2, b.get_height()),
+            xytext=(0, 3),
+            textcoords="offset points",
+            ha="center",
+            fontsize=9,
+            fontweight="bold",
+        )
+    ax_a.annotate(
+        f"but {nv['monotone']}/{nv['n']}\nmonotone (ordinal)",
+        (3, a_vals[3]),
+        xytext=(0, 40),
+        textcoords="offset points",
+        ha="center",
+        fontsize=8,
+        color="#B84A3E",
+        style="italic",
+    )
     ax_a.set_xticks(range(4))
     ax_a.set_xticklabels(a_labs, fontsize=9)
     ax_a.set_ylim(0, 118)
     ax_a.set_ylabel("Reviewers in full agreement (%)", fontsize=11)
-    ax_a.set_title(f"Concordance by level  (Fleiss κ = {conc['fleiss_kappa']:.2f})",
-                   fontsize=12, fontweight="bold")
+    ax_a.set_title(
+        f"Concordance by level  (Fleiss κ = {conc['fleiss_kappa']:.2f})",
+        fontsize=12,
+        fontweight="bold",
+    )
 
     # B: NOVEL evidence-ladder calibration -- reviewer marginals ordered by mean level
     cal = sc["calibration"]
@@ -114,29 +159,54 @@ def figure_reviewer_concordance(state_path: Path, out_png: Path) -> None:
     w = 0.8 / len(order)
     for i, r in enumerate(order):
         offset = (i - (len(order) - 1) / 2) * w
-        ax_b.bar(xb + offset, [marg[r][lab] for lab in labs], w,
-                 label=f"{r} (μ={cal['means'][r]:.1f})", color=shades[r], edgecolor="white", zorder=2)
+        ax_b.bar(
+            xb + offset,
+            [marg[r][lab] for lab in labs],
+            w,
+            label=f"{r} (μ={cal['means'][r]:.1f})",
+            color=shades[r],
+            edgecolor="white",
+            zorder=2,
+        )
     ax_b.set_xticks(xb)
     ax_b.set_xticklabels([lab.replace("_EVIDENCE", "").title() for lab in labs], fontsize=8)
     ax_b.set_ylabel("Novel genes (count)", fontsize=11)
     med = sc["consensus_is_median"]
-    ax_b.set_title(f"Novel evidence-ladder: reviewer calibration\n"
-                   f"consensus = median ({med['reviewer']}) in {med['match']}/{med['n']}",
-                   fontsize=11, fontweight="bold")
+    ax_b.set_title(
+        f"Novel evidence-ladder: reviewer calibration\n"
+        f"consensus = median ({med['reviewer']}) in {med['match']}/{med['n']}",
+        fontsize=11,
+        fontweight="bold",
+    )
     ax_b.legend(frameon=False, fontsize=8, title="reviewer (mean level)")
 
     # C: reviewer web usage by class -- evidence-bundle sufficiency
     web = conc["web"]
     wv = [web["by_class"][c]["frac"] * 100 for c in _CLASSES]
-    b3 = ax_c.bar(range(len(_CLASSES)), wv,
-                  color=[SOURCE_COLORS["uniprot"], SOURCE_COLORS["affinage"], SOURCE_COLORS["both"]],
-                  edgecolor="white", zorder=2, width=0.6)
+    b3 = ax_c.bar(
+        range(len(_CLASSES)),
+        wv,
+        color=[SOURCE_COLORS["uniprot"], SOURCE_COLORS["affinage"], SOURCE_COLORS["both"]],
+        edgecolor="white",
+        zorder=2,
+        width=0.6,
+    )
     for b, c in zip(b3, _CLASSES, strict=True):
-        ax_c.annotate(f"{b.get_height():.0f}%\nn={web['by_class'][c]['n']}",
-                      (b.get_x() + b.get_width() / 2, b.get_height()),
-                      xytext=(0, 3), textcoords="offset points", ha="center", fontsize=9)
-    ax_c.axhline(web["overall"]["frac"] * 100, ls="--", color="#333333", lw=1,
-                 label=f"overall {web['overall']['frac'] * 100:.0f}%")
+        ax_c.annotate(
+            f"{b.get_height():.0f}%\nn={web['by_class'][c]['n']}",
+            (b.get_x() + b.get_width() / 2, b.get_height()),
+            xytext=(0, 3),
+            textcoords="offset points",
+            ha="center",
+            fontsize=9,
+        )
+    ax_c.axhline(
+        web["overall"]["frac"] * 100,
+        ls="--",
+        color="#333333",
+        lw=1,
+        label=f"overall {web['overall']['frac'] * 100:.0f}%",
+    )
     ax_c.set_xticks(range(len(_CLASSES)))
     ax_c.set_xticklabels([c.replace("_", "\n") for c in _CLASSES], fontsize=9)
     ax_c.set_ylim(0, 100)
@@ -144,8 +214,12 @@ def figure_reviewer_concordance(state_path: Path, out_png: Path) -> None:
     ax_c.set_title("Reviewer web use → bundle sufficiency", fontsize=12, fontweight="bold")
     ax_c.legend(frameon=False, fontsize=9)
 
-    fig.suptitle("Figure 0 — Inter-reviewer concordance & evidence sufficiency "
-                 "(ground-truth characterization)", fontsize=14, fontweight="bold")
+    fig.suptitle(
+        "Figure 0 — Inter-reviewer concordance & evidence sufficiency "
+        "(ground-truth characterization)",
+        fontsize=14,
+        fontweight="bold",
+    )
     fig.tight_layout(rect=(0, 0, 1, 0.95))
     _save(fig, out_png)
 
@@ -167,42 +241,78 @@ def figure_source_winner(state_path: Path, out_png: Path) -> None:
     winner_src = state["source"]
     srcs = [s for s in _SOURCE_ORDER if f"{s}::single_call" in cells]
 
-    fig, (ax_l, ax_r) = plt.subplots(1, 2, figsize=(16, 6.5),
-                                     gridspec_kw={"width_ratios": [3, 1.3]})
+    fig, (ax_l, ax_r) = plt.subplots(
+        1, 2, figsize=(16, 6.5), gridspec_kw={"width_ratios": [3, 1.3]}
+    )
 
     xs = list(range(len(_PROFILE)))
     ax_l.axhspan(lo * 100, hi * 100, color="#999999", alpha=0.14, zorder=0)
-    ax_l.annotate("human ceiling", (xs[-1], hi * 100), xytext=(-4, 4), textcoords="offset points",
-                  ha="right", fontsize=8, color="#666666")
+    ax_l.annotate(
+        "human ceiling",
+        (xs[-1], hi * 100),
+        xytext=(-4, 4),
+        textcoords="offset points",
+        ha="right",
+        fontsize=8,
+        color="#666666",
+    )
     for s in srcs:
         p = cells[f"{s}::single_call"]
         ys = [metric_value(p, m) * 100 for m, _ in _PROFILE]
         win = s == winner_src
-        ax_l.plot(xs, ys, "-o", color=SOURCE_COLORS.get(s, "#666"), lw=3.0 if win else 1.8,
-                  markersize=9 if win else 6, alpha=1.0 if win else 0.5, zorder=3 if win else 2,
-                  label=f"{s} (winner)" if win else s)
+        ax_l.plot(
+            xs,
+            ys,
+            "-o",
+            color=SOURCE_COLORS.get(s, "#666"),
+            lw=3.0 if win else 1.8,
+            markersize=9 if win else 6,
+            alpha=1.0 if win else 0.5,
+            zorder=3 if win else 2,
+            label=f"{s} (winner)" if win else s,
+        )
         if win:
             for x, y in zip(xs, ys, strict=True):
-                ax_l.annotate(f"{y:.0f}", (x, y), xytext=(0, 9), textcoords="offset points",
-                              ha="center", fontsize=9, fontweight="bold", color=SOURCE_COLORS.get(s))
+                ax_l.annotate(
+                    f"{y:.0f}",
+                    (x, y),
+                    xytext=(0, 9),
+                    textcoords="offset points",
+                    ha="center",
+                    fontsize=9,
+                    fontweight="bold",
+                    color=SOURCE_COLORS.get(s),
+                )
     ax_l.set_xticks(xs)
     ax_l.set_xticklabels([lab for _, lab in _PROFILE], fontsize=11)
     ax_l.set_xlim(-0.3, len(_PROFILE) - 0.7)
     ax_l.set_ylim(0, 108)
     ax_l.set_ylabel("Score (%)", fontsize=11)
     ax_l.grid(axis="x", ls=":", alpha=0.4)
-    ax_l.set_title("Source metric profile (single_call, completeness floor)",
-                   fontsize=12, fontweight="bold")
+    ax_l.set_title(
+        "Source metric profile (single_call, completeness floor)", fontsize=12, fontweight="bold"
+    )
     ax_l.legend(frameon=False, fontsize=10, loc="lower left")
 
     order = ["affinage", "uniprot", "both", "neither"]
     pv = [pref.get(p, 0) for p in order]
-    b = ax_r.barh(range(len(order)), pv,
-                  color=[SOURCE_COLORS.get(p, "#999999") for p in order], edgecolor="white", zorder=2)
+    b = ax_r.barh(
+        range(len(order)),
+        pv,
+        color=[SOURCE_COLORS.get(p, "#999999") for p in order],
+        edgecolor="white",
+        zorder=2,
+    )
     for bar, val in zip(b, pv, strict=True):
-        ax_r.annotate(str(val), (bar.get_width(), bar.get_y() + bar.get_height() / 2),
-                      xytext=(4, 0), textcoords="offset points", va="center", fontsize=10,
-                      fontweight="bold")
+        ax_r.annotate(
+            str(val),
+            (bar.get_width(), bar.get_y() + bar.get_height() / 2),
+            xytext=(4, 0),
+            textcoords="offset points",
+            va="center",
+            fontsize=10,
+            fontweight="bold",
+        )
     ax_r.set_yticks(range(len(order)))
     ax_r.set_yticklabels(order, fontsize=10)
     ax_r.invert_yaxis()
@@ -210,7 +320,182 @@ def figure_source_winner(state_path: Path, out_png: Path) -> None:
     ax_r.set_xlabel("reviewer preference votes", fontsize=10)
     ax_r.set_title("Human source preference", fontsize=12, fontweight="bold")
 
-    fig.suptitle("Figure 1 — Affinage wins the primary metric (cw-recall) and the human vote",
-                 fontsize=14, fontweight="bold")
+    fig.suptitle(
+        "Figure 1 — Affinage wins the primary metric (cw-recall) and the human vote",
+        fontsize=14,
+        fontweight="bold",
+    )
     fig.tight_layout(rect=(0, 0, 1, 0.95))
+    _save(fig, out_png)
+
+
+def figure_mode_panel(state_path: Path, out_png: Path) -> None:
+    """Figure 3: mode axis (single_call / cot / stepwise) x the agreement metrics."""
+    _setup_style()
+    cells = {
+        k: _panel_from_json(v) for k, v in json.loads(Path(state_path).read_text())["cells"].items()
+    }
+    order = [m for m in ("single_call", "cot", "stepwise") if m in cells]
+    x = np.arange(len(METRICS))
+    width = 0.8 / len(order)
+
+    fig, ax = plt.subplots(figsize=(9, 6))
+    for i, mode in enumerate(order):
+        offset = (i - (len(order) - 1) / 2) * width
+        values = [metric_value(cells[mode], m) * 100 for m in METRICS]
+        bars = ax.bar(
+            x + offset,
+            values,
+            width,
+            label=mode,
+            color=_MODE_COLORS.get(mode, "#666666"),
+            edgecolor="white",
+            linewidth=1.2,
+            zorder=2,
+        )
+        for b in bars:
+            ax.annotate(
+                f"{b.get_height():.0f}",
+                xy=(b.get_x() + b.get_width() / 2, b.get_height()),
+                xytext=(0, 2),
+                textcoords="offset points",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+            )
+    ax.set_xticks(x)
+    ax.set_xticklabels([METRIC_LABELS[m] for m in METRICS], fontsize=11)
+    ax.set_ylim(0, 108)
+    ax.set_ylabel("Agreement with consensus (%)", fontsize=12)
+    ax.set_title(
+        "Figure 3 — Mode axis on the final prompt (Sonnet 5)", fontsize=14, fontweight="bold"
+    )
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.12), ncol=len(order), frameon=False)
+    fig.tight_layout()
+    _save(fig, out_png)
+
+
+_BUILDUP_METRICS = [
+    ("category", "Classification (category)"),
+    ("novel_subclass", "Novel sub-class"),
+    ("unchar_subclass", "Unchar sub-class"),
+    ("coherence", "Coherence"),
+    ("coverage", "Coverage (n / 103)"),
+]
+
+
+def _buildup_val(pj: dict, metric: str) -> float:
+    if metric in ("coverage", "category"):
+        return pj[metric] * 100
+    c, n = pj[metric]
+    return (c / n * 100) if n else 0.0
+
+
+def figure_walkup_buildup(state_path: Path, out_png: Path) -> None:
+    """Figure 2: metric development as components are added to a blank prompt.
+
+    Reads run_walkup's walkup_state.json and plots each metric across
+    W0(floor) -> +CAT -> +GCR -> +NPR -> +UPR -> +PCC following the carried build
+    (each stage's selected framing), a star where a component is adopted, and a
+    coverage panel showing recovery as the prompt is assembled.
+    """
+    _setup_style()
+    st = json.loads(Path(state_path).read_text())
+    stages = [s for s in st["stages"] if s.get("selected") is not None]
+    if not stages:
+        raise ValueError("no selected stages yet to plot")
+
+    def selected_panel(s: dict) -> dict:
+        return s["prior"] if s["selected"] == "prior" else s["candidates"][s["selected"]]
+
+    labels = ["W0\n(floor)"] + [f"+{s['stage']}\n{s['selected']}" for s in stages]
+    panels = [stages[0]["prior"]] + [selected_panel(s) for s in stages]
+    x = np.arange(len(labels))
+    w0 = panels[0]
+
+    fig, axes = plt.subplots(2, 3, figsize=(16, 9))
+    axes = axes.flatten()
+    for i, (m, title) in enumerate(_BUILDUP_METRICS):
+        ax = axes[i]
+        y = [_buildup_val(p, m) for p in panels]
+        ax.axhline(_buildup_val(w0, m), ls="--", color="#999999", lw=1, zorder=1)
+        ax.plot(x, y, "-o", color="#2E5C8A", lw=2.2, markersize=7, zorder=3)
+        for j, s in enumerate(stages, start=1):
+            if s["selected"] != "prior":
+                ax.scatter(
+                    [x[j]],
+                    [y[j]],
+                    s=240,
+                    color="#E69F00",
+                    marker="*",
+                    edgecolors="black",
+                    linewidths=0.5,
+                    zorder=4,
+                )
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, fontsize=8)
+        ax.set_ylim(0, 108)
+        ax.set_title(title, fontsize=11, fontweight="bold")
+        ax.set_ylabel("%", fontsize=10)
+
+    final = panels[-1]
+    filled = st.get("components_filled", [])
+    axes[5].axis("off")
+    axes[5].text(
+        0.02,
+        0.5,
+        "adopted: "
+        + (" + ".join(filled) if filled else "none (blank W0 held)")
+        + f"\n\nfinal category: {final['category'] * 100:.0f}%"
+        + f"\nfinal coverage: {final['n']} / {N_REAL_GENES}"
+        + f"\ncoverage-weighted recall: {final['category'] * final['n'] / N_REAL_GENES * 100:.0f}%",
+        fontsize=11,
+        va="center",
+        family="monospace",
+    )
+    fig.suptitle(
+        "Figure 2 — Build-up prompt walkup (★ = component adopted)",
+        fontsize=13,
+        fontweight="bold",
+    )
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    _save(fig, out_png)
+
+
+def figure_order_spread(state_path: Path, out_png: Path) -> None:
+    """Figure 4: positional sensitivity -- cw-recall per order variant.
+
+    Reads run_order's order_state.json and plots cw-recall for each order variant
+    (O canonical + O1..O4), highlighting the winner and annotating the spread
+    (max - min) that quantifies how much component order alone moves the result.
+    """
+    _setup_style()
+    st = json.loads(Path(state_path).read_text())
+    cw = st["cw_recall"]
+    winner = st.get("winner")
+    variants = list(cw)
+    y = [cw[v] * 100 for v in variants]
+
+    fig, ax = plt.subplots(figsize=(8, 5.5))
+    colors = ["#B84A3E" if v == winner else "#2E5C8A" for v in variants]
+    bars = ax.bar(variants, y, color=colors, edgecolor="white", linewidth=1.2, zorder=2)
+    for b in bars:
+        ax.annotate(
+            f"{b.get_height():.1f}",
+            xy=(b.get_x() + b.get_width() / 2, b.get_height()),
+            xytext=(0, 2),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+    ax.set_ylim(0, max(y) + 8 if y else 100)
+    ax.set_ylabel("Coverage-weighted recall (%)", fontsize=12)
+    ax.set_xlabel("Component-order variant (O = canonical)", fontsize=11)
+    ax.set_title(
+        f"Figure 4 — Positional sensitivity (spread {st.get('spread', 0) * 100:.1f} pts; winner {winner})",
+        fontsize=13,
+        fontweight="bold",
+    )
+    fig.tight_layout()
     _save(fig, out_png)

--- a/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_walkup_candidates.py
+++ b/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_walkup_candidates.py
@@ -1,0 +1,234 @@
+"""Reasoned candidate framings for the build-up prompt walkup.
+
+The walkup starts from a blank prompt (W0) and adds one component per stage,
+testing 3 NEW framings per component (no canonical option) and carrying the
+winner forward. Directions are informed by the first flat run:
+
+- GCR / NPR / PCC reframings genuinely helped their goal metric, so we test the
+  validated 3-level ladders (simple -> +procedure/detail -> +guard).
+- CAT reframings were ~neutral-to-slightly-negative, so we test 3 distinct
+  task-lens directions rather than a ladder.
+- UPR reframings HURT unchar-subclass (-0.11 to -0.31) -- the v6 rules over-demote
+  named/annotated genes toward DARK_GENE. So all three UPR candidates are
+  re-authored corrections.
+
+CANDIDATES[component] = [(candidate_id, rationale, text), ...]  -- exactly 3 each.
+Each `text` is the full component block that fills that slot in the assembled
+single_call prompt.
+"""
+
+from architecture_benchmarking_workflow.bench_wording_alternates import (
+    GCR_FRAME_DECISION_TREE,
+    GCR_FRAME_GUARDED,
+    GCR_FRAME_SIMPLE,
+    NPR_FRAME_DECISION_TREE,
+    NPR_FRAME_SIMPLE,
+    PCC_FRAME_DETAILED,
+    PCC_FRAME_GUARDED,
+    PCC_FRAME_SIMPLE,
+)
+
+# =============================================================================
+# Newly authored texts (where reuse is inappropriate)
+# =============================================================================
+# All CAT candidates are multi-pathway-AWARE: they license 1-3 pathways as a guard
+# against forcing a heterogeneous cluster into one (matching the output-JSON guard
+# in OUTPUT_FORMAT_JSON). Multi-pathway is a constant, not a competing candidate;
+# the three lenses vary the task framing around it.
+
+# CAT — lean task statement; tests whether the elaboration earns its tokens.
+CAT_CONCISE = """
+MISSION: Analyze this gene cluster and:
+1. Identify the biological pathway(s) — a single dominant process, or 2-3 if the cluster genuinely
+   spans several — that explain why these genes cluster together.
+2. Categorize ALL genes as ESTABLISHED (known role in the pathway), NOVEL_ROLE (characterized
+   elsewhere), or UNCHARACTERIZED (no focused study).
+3. Prioritize NOVEL_ROLE and UNCHARACTERIZED genes for follow-up.
+"""
+
+# CAT — lead with the recall-first mission (understudied genes are the deliverable)
+# and license an honest "no coherent pathway" from the very first component.
+CAT_DISCOVERY_FIRST = """
+MISSION: Functional genomics experiments cluster genes by phenotypic similarity. The deliverable is
+to surface UNDERSTUDIED genes (UNCHARACTERIZED and NOVEL_ROLE) that merit experimental follow-up.
+To do that:
+1. Identify the pathway(s) that best explain why these genes cluster — a single dominant process, or
+   2-3 if the cluster genuinely spans several. This is the lens for discovery, not the end goal.
+2. Categorize ALL genes relative to that pathway (ESTABLISHED / NOVEL_ROLE / UNCHARACTERIZED).
+3. Prioritize the understudied genes for follow-up.
+
+If the genes do not share a coherent pathway, say so honestly rather than forcing a label — a clear
+"no coherent pathway" call is a valid and useful outcome.
+"""
+
+# CAT — anchor on the pathway first, since every downstream categorization depends on it.
+CAT_PATHWAY_ANCHORED = """
+MISSION: Every downstream call depends on correctly identifying what unites this cluster, so anchor
+there first.
+1. Determine the biological pathway(s) that explain the cluster — commit to a single dominant
+   process where one clearly fits, or 2-3 distinct processes if the cluster genuinely spans them. If
+   no process explains a substantial share of the genes, declare no coherent pathway.
+2. Categorize ALL genes against that pathway (ESTABLISHED / NOVEL_ROLE / UNCHARACTERIZED).
+3. Prioritize UNCHARACTERIZED and NOVEL_ROLE genes for follow-up.
+"""
+
+# UPR correction A — the v6 guard demoted named, domain-annotated genes to DARK/NASCENT. Make the
+# name+domain signal count: a named gene with domain annotation is ANNOTATED_ONLY, not DARK.
+UPR_NAME_RESPECTING = """
+PRECONDITION: This step applies ONLY to genes already categorized as UNCHARACTERIZED per the gene
+classification rules. If no genes were categorized as UNCHARACTERIZED, do nothing.
+
+SUB-CLASSIFICATION (UNCHARACTERIZED genes only): assign exactly one sub-class from the gene's bundle
+annotation. A standard gene name plus domain/motif annotation IS meaningful signal — do NOT demote a
+named, domain-annotated gene to DARK_GENE merely because no mechanistic study exists.
+- DARK_GENE: no standard name AND no domain/functional annotation whatsoever.
+- NASCENT: no standard name, but the annotation contains preliminary functional data.
+- ANNOTATED_ONLY: has a standard name and/or domain/motif annotation but no mechanistic study — this
+  is the default for named genes that lack a focused functional study.
+- NON_HUMAN_CHARACTERIZED: the annotation describes functional studies only in non-human organisms.
+"""
+
+# UPR correction B — rank by the HIGHEST level of evidence actually present, with no downward
+# tiebreak (the v6 "prefer lower" guard was the likely source of the unchar-subclass loss).
+UPR_EVIDENCE_LADDER = """
+PRECONDITION: This step applies ONLY to genes already categorized as UNCHARACTERIZED per the gene
+classification rules. If no genes were categorized as UNCHARACTERIZED, do nothing.
+
+SUB-CLASSIFICATION (UNCHARACTERIZED genes only): assign the sub-class matching the HIGHEST level of
+evidence present in the annotation. Evaluate in order and assign the first that matches; do not bias
+toward lower-information classes.
+- NON_HUMAN_CHARACTERIZED: functional studies described only in a non-human organism.
+- ANNOTATED_ONLY: a standard name with domain/motif annotation, no mechanistic study.
+- NASCENT: no standard name, but some preliminary functional data present.
+- DARK_GENE: none of the above — no name, no domain annotation, no functional data.
+"""
+
+# UPR correction C — revert to the canonical 4-subclass definitions (which scored 0.714), just
+# grounded in the bundle annotation and with no aggressive guard.
+UPR_CANONICAL_GROUNDED = """
+PRECONDITION: This step applies ONLY to genes already categorized as UNCHARACTERIZED per the gene
+classification rules. If no genes were categorized as UNCHARACTERIZED, do nothing.
+
+SUB-CLASSIFICATION (UNCHARACTERIZED genes only): assign exactly one sub-class based on the gene's
+bundle annotation.
+- DARK_GENE: no name, no functional characterization whatsoever.
+- NASCENT: no standard name, but some preliminary functional data exists.
+- ANNOTATED_ONLY: has a gene name and domain/motif annotations, but no mechanistic study.
+- NON_HUMAN_CHARACTERIZED: functionally studied in a non-human organism only.
+Assign exactly one sub-class per gene.
+"""
+
+# NPR correction — two-sided, diagnostic-driven. The model reproduces the conservative reviewer:
+# its dominant error is INDIRECT under-credited to NO (7 genes, chromatin/RNA genes in
+# chromatin/RNA clusters). A blanket "shared context = INDIRECT" (the earlier context_anchored)
+# recovered those but OVERSHOT — it collapsed correct PARTIAL genes (WDR61, ZC3H18) down to
+# INDIRECT and over-promoted unrelated NO genes (KDM4A, YEATS4, ZWINT) up to INDIRECT, netting
+# ~zero. This reframes the NO/INDIRECT boundary as same-process vs unrelated-process AND adds an
+# explicit PARTIAL guard (data touching the pathway stays PARTIAL) and an unrelated-process guard
+# (a shared generic compartment is not same-process) to hold both rungs.
+NPR_PROCESS_SCOPED = """
+PRECONDITION: This step applies ONLY to genes already categorized as NOVEL_ROLE per the gene classification rules. If no genes were categorized as NOVEL_ROLE (because no coherent pathway exists, or no genes fit the criteria), do nothing — no sub-classification is needed.
+
+SUB-CLASSIFICATION (NOVEL_ROLE genes only): assign exactly one sub-class based on how the bundle's annotation relates to the identified pathway.
+- NO_EVIDENCE: the gene's characterized function is in a process UNRELATED to this pathway.
+- INDIRECT_EVIDENCE: the gene acts in the SAME broad process or machinery as the pathway (e.g. a chromatin factor in a chromatin/centromere cluster; an RNA-processing factor in an RNA cluster) but the annotation reports no experimental link to the specific pathway.
+- PARTIAL_EVIDENCE: the annotation reports actual data touching this pathway — a physical interaction, proteomics/co-IP hit, co-expression, or a functional assay — but no focused mechanistic study.
+- CONTRADICTORY_EVIDENCE: the annotation describes a function incompatible with this pathway.
+
+Procedure (apply in order):
+1. Does the annotation describe a function incompatible with this pathway? → CONTRADICTORY_EVIDENCE.
+2. Does the annotation report experimental data touching this pathway (interaction, proteomics/co-IP, co-expression, functional assay)? → PARTIAL_EVIDENCE. Do NOT down-rank a gene that has such data to INDIRECT.
+3. Does the gene operate in the same broad process or machinery as the pathway, with no such data? → INDIRECT_EVIDENCE.
+4. Otherwise (function is in an unrelated process) → NO_EVIDENCE. Sharing only a generic compartment (e.g. "nuclear", "cytoplasmic") is NOT the same process — keep NO_EVIDENCE.
+"""
+
+# =============================================================================
+# Candidate banks (3 per component, each with a rationale)
+# =============================================================================
+
+CANDIDATES: dict[str, list[tuple[str, str, str]]] = {
+    "CAT": [
+        (
+            "concise",
+            "lean task statement (multi-pathway-aware) — tests whether the elaboration grounds the model or just spends tokens",
+            CAT_CONCISE,
+        ),
+        (
+            "discovery_first",
+            "lead with the recall-first mission + honest 'no coherent pathway' (multi-pathway-aware)",
+            CAT_DISCOVERY_FIRST,
+        ),
+        (
+            "pathway_anchored",
+            "anchor on rigorously fixing the pathway(s) first, since every downstream call depends on it (multi-pathway-aware)",
+            CAT_PATHWAY_ANCHORED,
+        ),
+    ],
+    "GCR": [
+        ("simple", "definitions only — baseline categorization rules", GCR_FRAME_SIMPLE),
+        (
+            "decision_tree",
+            "ordered gating procedure cuts category ambiguity — the first-run winner",
+            GCR_FRAME_DECISION_TREE,
+        ),
+        (
+            "guarded",
+            "decision-tree + default-to-NOVEL-when-uncertain — anti-overcrediting, recall-first",
+            GCR_FRAME_GUARDED,
+        ),
+    ],
+    "NPR": [
+        (
+            "simple",
+            "flat NO/INDIRECT/PARTIAL/CONTRADICTORY definitions — baseline",
+            NPR_FRAME_SIMPLE,
+        ),
+        (
+            "decision_tree",
+            "ordered procedure over the four evidence levels — first-run winner",
+            NPR_FRAME_DECISION_TREE,
+        ),
+        (
+            "process_scoped",
+            "two-sided: reframes NO/INDIRECT as unrelated-vs-same-process + guards PARTIAL (data stays PARTIAL) and NO (generic compartment isn't same-process) — recovers INDIRECT under-credits without collapsing PARTIAL",
+            NPR_PROCESS_SCOPED,
+        ),
+    ],
+    "UPR": [
+        (
+            "name_respecting",
+            "CORRECTED: a name+domain gene is ANNOTATED_ONLY, not DARK — undoes the v6 over-demotion that broke unchar-subclass",
+            UPR_NAME_RESPECTING,
+        ),
+        (
+            "evidence_ladder",
+            "CORRECTED: rank by highest evidence present with no downward tiebreak (the likely source of the v6 loss)",
+            UPR_EVIDENCE_LADDER,
+        ),
+        (
+            "canonical_grounded",
+            "CORRECTED: revert to the canonical 4-subclass rules (scored 0.714), bundle-grounded, no guard",
+            UPR_CANONICAL_GROUNDED,
+        ),
+    ],
+    "PCC": [
+        ("simple", "qualitative high/medium/low by fraction consistent — lean", PCC_FRAME_SIMPLE),
+        ("detailed", "explicit >70/50-70/30-50 percent thresholds per level", PCC_FRAME_DETAILED),
+        (
+            "guarded",
+            "thresholds + prefer-lower-confidence + honest no-pathway framing — corrects the model running 'hot' on coherence",
+            PCC_FRAME_GUARDED,
+        ),
+    ],
+}
+
+# Component order for the build-up (matches single_call component_order).
+WALKUP_ORDER = ("CAT", "GCR", "NPR", "UPR", "PCC")
+# Goal metric per stage (what select_winner optimizes at that stage).
+STAGE_GOAL = {
+    "CAT": "category",
+    "GCR": "category",
+    "NPR": "novel_subclass",
+    "UPR": "unchar_subclass",
+    "PCC": "coherence",
+}

--- a/tests/phase1_prompt_benchmarking/run_mode.py
+++ b/tests/phase1_prompt_benchmarking/run_mode.py
@@ -3,10 +3,10 @@
 
 Runs {single_call, cot, stepwise} on the 8-cluster slate (real clusters drive
 selection, the 3 decoys validate the final config), n=3, on the source and
-assembled prompt carried from the walkup (runs/walkup). Picks the mode
-holistically (delivery format legitimately trades metrics off). Writes the
-latest-pointer runs/mode/mode_state.json, archives the state alongside the
-timestamped run dir, and pushes the run into the runs submodule.
+assembled prompt carried from the walkup. Picks the mode holistically (delivery
+format legitimately trades metrics off). Writes the latest-pointer
+benchmarking_outputs/mode/mode_state.json; each run archives in place under
+benchmarking_outputs/mode/<source>_<stamp>/ (nothing overwritten).
 
 Component-mapping caveat: the walkup tunes the single_call components
 (CAT/GCR/NPR/UPR/PCC). cot/stepwise use different component keys
@@ -41,7 +41,6 @@ from architecture_benchmarking_workflow.bench_pipeline_common import (
     panel_json,
     prepare,
     print_panel,
-    push_run,
     read_carry,
     run_stamp,
     score_cell,
@@ -61,16 +60,12 @@ def _overrides_for(mode: str, final: dict[str, str]) -> dict[str, str]:
 
 
 def _config_for(source: str, stamp: str, dry_run: bool, score_only: bool):
-    """Fresh (run) or non-destructive (score-only) config in runs/mode/<stamp>/mode/.
-    experiment_id stays flat ("mode") so run_id / trace paths never contain slashes."""
+    """Config for the mode run. Runs archive under benchmarking_outputs/mode/
+    <source>_<stamp>/; score-only just loads (dir found via latest_run_dir)."""
     cfg = load_config(CONFIGS / f"source_{source}.yaml")
-    out_root = OUTPUTS / "mode" / stamp
     if score_only:
-        cfg.experiment_id = "mode"
-        cfg.paths.output_dir = out_root
-        cfg.run.overwrite_outputs = True  # we only read it, no wipe
         return cfg
-    return prepare(cfg, "mode", dry_run, out_root=out_root)
+    return prepare(cfg, f"{source}_{stamp}", dry_run, out_root=OUTPUTS / "mode")
 
 
 def run_mode(dry_run: bool, source: str | None = None, score_only: bool = False) -> None:
@@ -80,15 +75,7 @@ def run_mode(dry_run: bool, source: str | None = None, score_only: bool = False)
     if not source:
         raise SystemExit("run_mode needs a source; run run_walkup.py first (or pass --source).")
     filled = carry.get("components_filled", [])
-
-    if score_only:
-        prev = latest_run_dir("mode")
-        if prev is None:
-            raise SystemExit("[mode] no prior run under runs/mode/ to score")
-        stamp = prev.name
-        print(f"[mode] --score-only: re-scoring run {stamp}")
-    else:
-        stamp = run_stamp()
+    stamp = run_stamp()
     print(f"[mode] source={source} carrying walkup build: {'+'.join(filled) or 'blank W0'}")
 
     gt, coh = load_gt_and_coherence()
@@ -105,8 +92,12 @@ def run_mode(dry_run: bool, source: str | None = None, score_only: bool = False)
         snapshot = _build_config_snapshot(cfg, mode={"source": source, "carried": filled})
         print(f"[mode] {list(MODES)} -> {cfg.experiment_id}")
         _run_benchmark_loop(cfg, specs, snapshot, phase_label="mode")
+        out = cfg.experiment_output_dir
+    else:
+        out = latest_run_dir("mode", source)
+        if out is None:
+            raise SystemExit(f"[mode] no prior run for {source} under {OUTPUTS / 'mode'}")
 
-    out = cfg.experiment_output_dir
     cells = {mode: score_cell(out, gt, coh, mode) for mode in MODES}
     decoys = {mode: decoy_results(out, condition=mode) for mode in MODES}
 
@@ -133,11 +124,6 @@ def run_mode(dry_run: bool, source: str | None = None, score_only: bool = False)
         cells={k: panel_json(v) for k, v in cells.items()},
         dominated=dominated,
     )
-    archive = OUTPUTS / "mode" / stamp / "mode_state.json"
-    archive.parent.mkdir(parents=True, exist_ok=True)
-    archive.write_text(STATE_PATH.read_text())
-    if not dry_run:
-        push_run("mode", f"mode run {stamp}: winner {winner_mode}")
 
 
 def main() -> None:

--- a/tests/phase1_prompt_benchmarking/run_mode.py
+++ b/tests/phase1_prompt_benchmarking/run_mode.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+"""Step 3 of the pipeline: MODE on the walkup's final assembled prompt.
+
+Runs {single_call, cot, stepwise} on the 8-cluster slate (real clusters drive
+selection, the 3 decoys validate the final config), n=3, on the source and
+assembled prompt carried from the walkup (runs/walkup). Picks the mode
+holistically (delivery format legitimately trades metrics off). Writes the
+latest-pointer runs/mode/mode_state.json, archives the state alongside the
+timestamped run dir, and pushes the run into the runs submodule.
+
+Component-mapping caveat: the walkup tunes the single_call components
+(CAT/GCR/NPR/UPR/PCC). cot/stepwise use different component keys
+(cGCR/cPri/cPSC/cVer/...); only CAT (and SC) are shared. So single_call runs the
+full tuned prompt, while cot/stepwise carry only the tuned CAT lens and keep
+canonical text for their own components. This is a fair mode comparison, not a
+verbatim prompt transplant.
+
+--dry-run exercises the plumbing with mock outputs (zero API); --score-only
+re-scores the existing run dirs and rewrites state without any API calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from architecture_benchmarking_workflow.bench_configparse import load_config
+from architecture_benchmarking_workflow.bench_orchestrator import (
+    RunSpec,
+    _build_config_snapshot,
+    _run_benchmark_loop,
+)
+from architecture_benchmarking_workflow.bench_pipeline_common import (
+    CONFIGS,
+    HOLISTIC_METRICS,
+    MODES,
+    OUTPUTS,
+    PRIMARY,
+    decoy_results,
+    latest_run_dir,
+    load_gt_and_coherence,
+    panel_json,
+    prepare,
+    print_panel,
+    push_run,
+    read_carry,
+    run_stamp,
+    score_cell,
+    select_holistic,
+    write_state,
+)
+from architecture_benchmarking_workflow.bench_routes import MODE_REGISTRY
+
+STATE_PATH = OUTPUTS / "mode" / "mode_state.json"
+
+
+def _overrides_for(mode: str, final: dict[str, str]) -> dict[str, str]:
+    """single_call gets the full tuned prompt; cot/stepwise carry only shared CAT."""
+    if mode == "single_call":
+        return dict(final)
+    return {"CAT": final["CAT"]} if final.get("CAT") else {}
+
+
+def _config_for(source: str, stamp: str, dry_run: bool, score_only: bool):
+    """Fresh (run) or non-destructive (score-only) config in runs/mode/<stamp>/mode/.
+    experiment_id stays flat ("mode") so run_id / trace paths never contain slashes."""
+    cfg = load_config(CONFIGS / f"source_{source}.yaml")
+    out_root = OUTPUTS / "mode" / stamp
+    if score_only:
+        cfg.experiment_id = "mode"
+        cfg.paths.output_dir = out_root
+        cfg.run.overwrite_outputs = True  # we only read it, no wipe
+        return cfg
+    return prepare(cfg, "mode", dry_run, out_root=out_root)
+
+
+def run_mode(dry_run: bool, source: str | None = None, score_only: bool = False) -> None:
+    carry = read_carry("walkup")
+    source = source or carry.get("source")
+    final = carry.get("final_component_texts", {})
+    if not source:
+        raise SystemExit("run_mode needs a source; run run_walkup.py first (or pass --source).")
+    filled = carry.get("components_filled", [])
+
+    if score_only:
+        prev = latest_run_dir("mode")
+        if prev is None:
+            raise SystemExit("[mode] no prior run under runs/mode/ to score")
+        stamp = prev.name
+        print(f"[mode] --score-only: re-scoring run {stamp}")
+    else:
+        stamp = run_stamp()
+    print(f"[mode] source={source} carrying walkup build: {'+'.join(filled) or 'blank W0'}")
+
+    gt, coh = load_gt_and_coherence()
+    cfg = _config_for(source, stamp, dry_run, score_only)
+    if not score_only:
+        specs = [
+            RunSpec(
+                route=MODE_REGISTRY[mode],
+                condition_name=mode,
+                component_overrides=_overrides_for(mode, final),
+            )
+            for mode in MODES
+        ]
+        snapshot = _build_config_snapshot(cfg, mode={"source": source, "carried": filled})
+        print(f"[mode] {list(MODES)} -> {cfg.experiment_id}")
+        _run_benchmark_loop(cfg, specs, snapshot, phase_label="mode")
+
+    out = cfg.experiment_output_dir
+    cells = {mode: score_cell(out, gt, coh, mode) for mode in MODES}
+    decoys = {mode: decoy_results(out, condition=mode) for mode in MODES}
+
+    print("\n[mode] mode panels:")
+    for mode in MODES:
+        print_panel(mode, cells[mode])
+    for mode in MODES:
+        passes = sum(1 for d in decoys[mode] if d["passed"])
+        print(f"[mode] decoys {mode}: {passes}/{len(decoys[mode])} passed")
+
+    winner_mode, dominated = select_holistic(cells, PRIMARY, HOLISTIC_METRICS)
+    print(f"\n[mode] holistic winner: {winner_mode}")
+    if dominated:
+        print(f"[mode] dominated modes: {dominated}")
+
+    write_state(
+        STATE_PATH,
+        step="mode",
+        source=source,
+        winner=winner_mode,
+        decoys=decoys,
+        carry={"source": source, "mode": winner_mode},
+        stamp=stamp,
+        cells={k: panel_json(v) for k, v in cells.items()},
+        dominated=dominated,
+    )
+    archive = OUTPUTS / "mode" / stamp / "mode_state.json"
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    archive.write_text(STATE_PATH.read_text())
+    if not dry_run:
+        push_run("mode", f"mode run {stamp}: winner {winner_mode}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="mock outputs, zero API cost")
+    ap.add_argument(
+        "--score-only", action="store_true", help="re-score existing run dirs, no API calls"
+    )
+    ap.add_argument("--source", help="override the source carried from the walkup")
+    args = ap.parse_args()
+    run_mode(args.dry_run, args.source, args.score_only)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/phase1_prompt_benchmarking/run_order.py
+++ b/tests/phase1_prompt_benchmarking/run_order.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+"""Step 4 of the pipeline: component ORDER on the tuned prompt.
+
+Holds the source, mode, and component *content* fixed (from the walkup + mode
+carries) and permutes the component_order to measure positional sensitivity.
+Runs the order variants resolve_order_variant_ids("all") = [O, O1, O2, O3, O4]
+on the 8-cluster slate (real clusters drive selection, the 3 decoys validate),
+n=3, picks the order holistically, and reports the cw-recall spread across
+variants (how much order alone moves the result). Writes runs/order/
+order_state.json, archives alongside the timestamped run, and pushes to the runs
+submodule.
+
+Scope (V1): the walkup tunes the single_call component keys, so order is applied
+to the single_call route with the walkup's assembled texts injected -- even if
+the mode winner was cot/stepwise (those use different component keys, so a
+verbatim order transplant is out of scope for now). The mode winner is reported
+for context.
+
+--dry-run exercises the plumbing with mock outputs (zero API); --score-only
+re-scores the existing run dirs and rewrites state without any API calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from architecture_benchmarking_workflow.bench_configparse import load_config
+from architecture_benchmarking_workflow.bench_orchestrator import (
+    RunSpec,
+    _build_config_snapshot,
+    _run_benchmark_loop,
+)
+from architecture_benchmarking_workflow.bench_order import (
+    apply_order_variant,
+    resolve_order_variant_ids,
+)
+from architecture_benchmarking_workflow.bench_pipeline_common import (
+    CONFIGS,
+    HOLISTIC_METRICS,
+    OUTPUTS,
+    PRIMARY,
+    decoy_results,
+    latest_run_dir,
+    load_gt_and_coherence,
+    metric_value,
+    panel_json,
+    prepare,
+    print_panel,
+    push_run,
+    read_carry,
+    run_stamp,
+    score_cell,
+    select_holistic,
+    write_state,
+)
+from architecture_benchmarking_workflow.bench_routes import MODE_REGISTRY
+
+STATE_PATH = OUTPUTS / "order" / "order_state.json"
+# V1 permutes the single_call route -- the mode whose component keys the walkup tuned.
+BASE_MODE = "single_call"
+
+
+def _config_for(source: str, stamp: str, dry_run: bool, score_only: bool):
+    """Fresh (run) or non-destructive (score-only) config in runs/order/<stamp>/order/.
+    experiment_id stays flat ("order") so run_id / trace paths never contain slashes."""
+    cfg = load_config(CONFIGS / f"source_{source}.yaml")
+    out_root = OUTPUTS / "order" / stamp
+    if score_only:
+        cfg.experiment_id = "order"
+        cfg.paths.output_dir = out_root
+        cfg.run.overwrite_outputs = True  # we only read it, no wipe
+        return cfg
+    return prepare(cfg, "order", dry_run, out_root=out_root)
+
+
+def run_order(dry_run: bool, source: str | None = None, score_only: bool = False) -> None:
+    mode_carry = read_carry("mode")
+    walkup_carry = read_carry("walkup")
+    source = source or mode_carry.get("source") or walkup_carry.get("source")
+    if not source:
+        raise SystemExit("run_order needs a source; run the mode step first (or pass --source).")
+    final = walkup_carry.get("final_component_texts", {})
+    mode_winner = mode_carry.get("mode", "?")
+    variant_ids = resolve_order_variant_ids("all")
+    print(
+        f"[order] source={source} mode-winner={mode_winner} "
+        f"(order applied to {BASE_MODE}); variants={variant_ids}"
+    )
+
+    if score_only:
+        prev = latest_run_dir("order")
+        if prev is None:
+            raise SystemExit("[order] no prior run under runs/order/ to score")
+        stamp = prev.name
+        print(f"[order] --score-only: re-scoring run {stamp}")
+    else:
+        stamp = run_stamp()
+
+    gt, coh = load_gt_and_coherence()
+    cfg = _config_for(source, stamp, dry_run, score_only)
+    base_route = MODE_REGISTRY[BASE_MODE]
+    if not score_only:
+        specs = [
+            RunSpec(
+                route=apply_order_variant(base_route, vid),
+                condition_name=vid,
+                component_overrides=dict(final),
+            )
+            for vid in variant_ids
+        ]
+        snapshot = _build_config_snapshot(
+            cfg, order={"source": source, "mode_winner": mode_winner, "variants": variant_ids}
+        )
+        print(f"[order] {variant_ids} -> {cfg.experiment_id}")
+        _run_benchmark_loop(cfg, specs, snapshot, phase_label="order")
+
+    out = cfg.experiment_output_dir
+    cells = {vid: score_cell(out, gt, coh, vid) for vid in variant_ids}
+    decoys = {vid: decoy_results(out, condition=vid) for vid in variant_ids}
+
+    print("\n[order] variant panels:")
+    for vid in variant_ids:
+        print_panel(vid, cells[vid])
+    for vid in variant_ids:
+        passes = sum(1 for d in decoys[vid] if d["passed"])
+        print(f"[order] decoys {vid}: {passes}/{len(decoys[vid])} passed")
+
+    cw = {vid: metric_value(p, PRIMARY) for vid, p in cells.items()}
+    spread = max(cw.values()) - min(cw.values())
+    winner_order, dominated = select_holistic(cells, PRIMARY, HOLISTIC_METRICS)
+    print(f"\n[order] holistic winner: {winner_order}  (cw-recall spread {spread:.3f})")
+    if dominated:
+        print(f"[order] dominated variants: {dominated}")
+
+    write_state(
+        STATE_PATH,
+        step="order",
+        source=source,
+        winner=winner_order,
+        decoys=decoys,
+        carry={"source": source, "mode": mode_winner, "order": winner_order},
+        stamp=stamp,
+        cells={k: panel_json(v) for k, v in cells.items()},
+        cw_recall=cw,
+        spread=round(spread, 4),
+        dominated=dominated,
+    )
+    archive = OUTPUTS / "order" / stamp / "order_state.json"
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    archive.write_text(STATE_PATH.read_text())
+    if not dry_run:
+        push_run("order", f"order run {stamp}: winner {winner_order}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="mock outputs, zero API cost")
+    ap.add_argument(
+        "--score-only", action="store_true", help="re-score existing run dirs, no API calls"
+    )
+    ap.add_argument("--source", help="override the source carried from the mode step")
+    args = ap.parse_args()
+    run_order(args.dry_run, args.source, args.score_only)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/phase1_prompt_benchmarking/run_order.py
+++ b/tests/phase1_prompt_benchmarking/run_order.py
@@ -6,9 +6,9 @@ carries) and permutes the component_order to measure positional sensitivity.
 Runs the order variants resolve_order_variant_ids("all") = [O, O1, O2, O3, O4]
 on the 8-cluster slate (real clusters drive selection, the 3 decoys validate),
 n=3, picks the order holistically, and reports the cw-recall spread across
-variants (how much order alone moves the result). Writes runs/order/
-order_state.json, archives alongside the timestamped run, and pushes to the runs
-submodule.
+variants (how much order alone moves the result). Writes the latest-pointer
+benchmarking_outputs/order/order_state.json; each run archives in place under
+benchmarking_outputs/order/<source>_<stamp>/ (nothing overwritten).
 
 Scope (V1): the walkup tunes the single_call component keys, so order is applied
 to the single_call route with the walkup's assembled texts injected -- even if
@@ -46,7 +46,6 @@ from architecture_benchmarking_workflow.bench_pipeline_common import (
     panel_json,
     prepare,
     print_panel,
-    push_run,
     read_carry,
     run_stamp,
     score_cell,
@@ -61,16 +60,12 @@ BASE_MODE = "single_call"
 
 
 def _config_for(source: str, stamp: str, dry_run: bool, score_only: bool):
-    """Fresh (run) or non-destructive (score-only) config in runs/order/<stamp>/order/.
-    experiment_id stays flat ("order") so run_id / trace paths never contain slashes."""
+    """Config for the order run. Runs archive under benchmarking_outputs/order/
+    <source>_<stamp>/; score-only just loads (dir found via latest_run_dir)."""
     cfg = load_config(CONFIGS / f"source_{source}.yaml")
-    out_root = OUTPUTS / "order" / stamp
     if score_only:
-        cfg.experiment_id = "order"
-        cfg.paths.output_dir = out_root
-        cfg.run.overwrite_outputs = True  # we only read it, no wipe
         return cfg
-    return prepare(cfg, "order", dry_run, out_root=out_root)
+    return prepare(cfg, f"{source}_{stamp}", dry_run, out_root=OUTPUTS / "order")
 
 
 def run_order(dry_run: bool, source: str | None = None, score_only: bool = False) -> None:
@@ -87,15 +82,7 @@ def run_order(dry_run: bool, source: str | None = None, score_only: bool = False
         f"(order applied to {BASE_MODE}); variants={variant_ids}"
     )
 
-    if score_only:
-        prev = latest_run_dir("order")
-        if prev is None:
-            raise SystemExit("[order] no prior run under runs/order/ to score")
-        stamp = prev.name
-        print(f"[order] --score-only: re-scoring run {stamp}")
-    else:
-        stamp = run_stamp()
-
+    stamp = run_stamp()
     gt, coh = load_gt_and_coherence()
     cfg = _config_for(source, stamp, dry_run, score_only)
     base_route = MODE_REGISTRY[BASE_MODE]
@@ -113,8 +100,12 @@ def run_order(dry_run: bool, source: str | None = None, score_only: bool = False
         )
         print(f"[order] {variant_ids} -> {cfg.experiment_id}")
         _run_benchmark_loop(cfg, specs, snapshot, phase_label="order")
+        out = cfg.experiment_output_dir
+    else:
+        out = latest_run_dir("order", source)
+        if out is None:
+            raise SystemExit(f"[order] no prior run for {source} under {OUTPUTS / 'order'}")
 
-    out = cfg.experiment_output_dir
     cells = {vid: score_cell(out, gt, coh, vid) for vid in variant_ids}
     decoys = {vid: decoy_results(out, condition=vid) for vid in variant_ids}
 
@@ -145,11 +136,6 @@ def run_order(dry_run: bool, source: str | None = None, score_only: bool = False
         spread=round(spread, 4),
         dominated=dominated,
     )
-    archive = OUTPUTS / "order" / stamp / "order_state.json"
-    archive.parent.mkdir(parents=True, exist_ok=True)
-    archive.write_text(STATE_PATH.read_text())
-    if not dry_run:
-        push_run("order", f"order run {stamp}: winner {winner_order}")
 
 
 def main() -> None:

--- a/tests/phase1_prompt_benchmarking/run_walkup.py
+++ b/tests/phase1_prompt_benchmarking/run_walkup.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python
+"""Step 2 of the pipeline: the build-up prompt WALKUP -- paused, human-gated.
+
+The walkup builds the prompt from a blank W0 by adding one component per stage
+(CAT -> GCR -> NPR -> UPR -> PCC). Rather than auto-selecting each stage on a
+single metric -- several target metrics are too low-powered on this 5-cluster
+benchmark to trust (unchar-subclass n~=6, coherence n=5) -- selection is a human
+gate: each stage runs its candidates, prints the FULL metric panel (with the
+sub-metric n's exposed so noise is visible), and stops. A person picks the winner
+with judgment, weighing the robust axis (category / coverage-weighted recall over
+133 genes) heavily and the noisy sub-metrics with skepticism.
+
+Usage (one stage at a time):
+    python run_walkup.py --stage CAT              # run CAT candidates, print panel, stop
+    python run_walkup.py --select CAT concise     # record the human's choice, carry it forward
+    python run_walkup.py --stage GCR              # ... next stage builds on the carried winner
+    ...
+    python run_walkup.py --finalize               # assemble final prompt + render the figure
+
+Runs on the source chosen by run_source.py (carry.source), or --source, else
+affinage. --dry-run exercises the plumbing with mock outputs (zero API).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+
+from architecture_benchmarking_workflow.bench_configparse import load_config
+from architecture_benchmarking_workflow.bench_evaluator import MetricPanel
+from architecture_benchmarking_workflow.bench_orchestrator import (
+    RunSpec,
+    _build_config_snapshot,
+    _run_benchmark_loop,
+)
+from architecture_benchmarking_workflow.bench_pipeline_common import (
+    CLUSTERS_ALL,
+    CONFIGS,
+    N_REAL_GENES,
+    OUTPUTS,
+    decoy_results,
+    load_gt_and_coherence,
+    metric_value,
+    panel_json,
+    read_carry,
+    score_cell,
+    validation_specs,
+)
+from architecture_benchmarking_workflow.bench_routes import MODE_REGISTRY
+from architecture_benchmarking_workflow.bench_walkup_candidates import (
+    CANDIDATES,
+    STAGE_GOAL,
+    WALKUP_ORDER,
+)
+
+OUT_DIR = OUTPUTS / "walkup"
+STATE_PATH = OUT_DIR / "walkup_state.json"
+
+# Reliability note shown at each gate so the human weights metrics correctly.
+_METRIC_POWER = "category n=103 robust · novel n~=40 soft · unchar n~=7 NOISE · coherence n=4 NOISE"
+
+
+def _cand_text(stage: str) -> dict[str, str]:
+    return {cid: text for cid, _r, text in CANDIDATES[stage]}
+
+
+def _base_config(dry_run: bool, source: str, reps: int | None = None):
+    cfg = load_config(CONFIGS / f"source_{source}.yaml")
+    cfg.paths.output_dir = OUT_DIR
+    cfg.paths.benchmark_clusters_csv = CLUSTERS_ALL  # 8-slate: score 103 + validate abstention
+    cfg.run.overwrite_outputs = True
+    cfg.run.dry_run = dry_run
+    if reps is not None:
+        cfg.run.num_replicates = reps
+    cfg.mcp.preflight = False
+    return cfg
+
+
+def _load_state() -> dict:
+    if STATE_PATH.exists():
+        return json.loads(STATE_PATH.read_text())
+    return {
+        "step": "walkup",
+        "source": None,
+        "carried": dict.fromkeys(WALKUP_ORDER, ""),
+        "stages": [],
+        "order": list(WALKUP_ORDER),
+    }
+
+
+def _save_state(st: dict) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    st["components_filled"] = [s for s in WALKUP_ORDER if st["carried"].get(s)]
+    STATE_PATH.write_text(json.dumps(st, indent=2))
+
+
+def _upsert_stage(st: dict, record: dict) -> None:
+    st["stages"] = [s for s in st["stages"] if s["stage"] != record["stage"]]
+    st["stages"].append(record)
+    st["stages"].sort(key=lambda s: WALKUP_ORDER.index(s["stage"]))
+
+
+def _row(label: str, p: MetricPanel, best: bool, abstain: str) -> str:
+    nov, unc, coh = p.novel_subclass, p.unchar_subclass, p.coherence
+    return (
+        f"   {label:16} cw={metric_value(p, 'coverage_weighted_category'):.3f} "
+        f"cat={p.category:.3f} cov={p.n}/{N_REAL_GENES} coh={coh[0]}/{coh[1]} abst={abstain} "
+        f"nov={nov[0]}/{nov[1]} unc={unc[0]}/{unc[1]} fail={p.failures}"
+        f"{'  <- best cw-recall' if best else ''}"
+    )
+
+
+def _print_panel(stage, prior, cands, prior_ab, cand_ab) -> None:
+    all_cells = {"prior": prior, **cands}
+    best = max(all_cells, key=lambda k: metric_value(all_cells[k], "coverage_weighted_category"))
+    print(f"\n[{stage}] goal={STAGE_GOAL[stage]}   ({_METRIC_POWER})")
+    print(_row("prior", prior, best == "prior", prior_ab))
+    for cid, _r, _t in CANDIDATES[stage]:
+        print(_row(cid, cands[cid], best == cid, cand_ab[cid]))
+    print(f"\n   -> choose:  python run_walkup.py --select {stage} <candidate|prior>")
+
+
+def cmd_stage(stage: str, dry_run: bool, source_arg: str | None, reps: int | None = None) -> None:
+    st = _load_state()
+    source = source_arg or st.get("source") or read_carry("source").get("source") or "affinage"
+    st["source"] = source
+    carried = st["carried"]
+    print(
+        f"[walkup] stage {stage} on source={source}; "
+        f"carried build: {'+'.join(st['components_filled']) if st.get('components_filled') else 'blank W0'}"
+    )
+
+    gt, coh = load_gt_and_coherence()
+    cfg = _base_config(dry_run, source, reps)
+    cfg.experiment_id = stage
+    out = cfg.experiment_output_dir
+    shutil.rmtree(out, ignore_errors=True)
+
+    specs = [
+        RunSpec(
+            route=MODE_REGISTRY["single_call"],
+            condition_name=f"{stage}_prior",
+            component_overrides={**carried},
+        )
+    ]
+    for cid, _r, text in CANDIDATES[stage]:
+        specs.append(
+            RunSpec(
+                route=MODE_REGISTRY["single_call"],
+                condition_name=f"{stage}_{cid}",
+                component_overrides={**carried, stage: text},
+            )
+        )
+    snapshot = _build_config_snapshot(
+        cfg, walkup={"stage": stage, "carried": st.get("components_filled", [])}
+    )
+    _run_benchmark_loop(cfg, specs, snapshot, phase_label=f"walkup:{stage}")
+
+    prior = score_cell(out, gt, coh, f"{stage}_prior")
+    cands = {cid: score_cell(out, gt, coh, f"{stage}_{cid}") for cid, _r, _t in CANDIDATES[stage]}
+    controls = validation_specs(gt)
+
+    def _abst(cond: str) -> str:
+        rows = decoy_results(out, condition=cond, specs=controls)
+        return f"{sum(1 for d in rows if d['passed'])}/{len(rows)}"
+
+    prior_ab = _abst(f"{stage}_prior")
+    cand_ab = {cid: _abst(f"{stage}_{cid}") for cid, _r, _t in CANDIDATES[stage]}
+    _upsert_stage(
+        st,
+        {
+            "stage": stage,
+            "goal": STAGE_GOAL[stage],
+            "prior": panel_json(prior),
+            "prior_abstain": prior_ab,
+            "candidates": {cid: panel_json(p) for cid, p in cands.items()},
+            "candidate_abstain": cand_ab,
+            "selected": None,
+        },
+    )
+    _save_state(st)
+    _print_panel(stage, prior, cands, prior_ab, cand_ab)
+
+
+def cmd_select(stage: str, choice: str) -> None:
+    st = _load_state()
+    rec = next((s for s in st["stages"] if s["stage"] == stage), None)
+    if rec is None:
+        raise SystemExit(
+            f"stage {stage} has not been run yet (python run_walkup.py --stage {stage})"
+        )
+    texts = _cand_text(stage)
+    if choice != "prior" and choice not in texts:
+        raise SystemExit(f"unknown candidate {choice!r}; options: {['prior', *texts]}")
+    rec["selected"] = choice
+    st["carried"][stage] = "" if choice == "prior" else texts[choice]
+    _save_state(st)
+    filled = st["components_filled"]
+    print(
+        f"[walkup] recorded {stage} <- {choice}.  build so far: "
+        f"{' + '.join(filled) if filled else 'blank W0'}"
+    )
+    nxt = [s for s in WALKUP_ORDER if s not in {r["stage"] for r in st["stages"] if r["selected"]}]
+    if nxt:
+        print(f"[walkup] next: python run_walkup.py --stage {nxt[0]}")
+    else:
+        print("[walkup] all stages chosen -> python run_walkup.py --finalize")
+
+
+def cmd_finalize() -> None:
+    st = _load_state()
+    unresolved = [s["stage"] for s in st["stages"] if s["selected"] is None]
+    missing = [s for s in WALKUP_ORDER if s not in {r["stage"] for r in st["stages"]}]
+    if unresolved or missing:
+        raise SystemExit(f"cannot finalize; unrun={missing} unselected={unresolved}")
+    carried = st["carried"]
+    filled = st["components_filled"]
+    st["winner"] = "+".join(filled) if filled else "blank_W0"
+    st["carry"] = {
+        "source": st["source"],
+        "final_component_texts": {k: v for k, v in carried.items() if v},
+        "components_filled": filled,
+    }
+    st["selected_components"] = {s["stage"]: s["selected"] for s in st["stages"]}
+    _save_state(st)
+    print(
+        f"[walkup] finalized. build: {' + '.join(filled) if filled else 'blank W0 (nothing adopted)'}"
+    )
+    print(f"[walkup] render figure: figure_walkup_buildup('{STATE_PATH}', out.png)")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--stage", choices=list(WALKUP_ORDER), help="run one stage's candidates and stop"
+    )
+    ap.add_argument(
+        "--select",
+        nargs=2,
+        metavar=("STAGE", "CHOICE"),
+        help="record the human's pick for a stage (candidate id or 'prior')",
+    )
+    ap.add_argument(
+        "--finalize", action="store_true", help="assemble final prompt from carried picks"
+    )
+    ap.add_argument("--dry-run", action="store_true", help="mock outputs, zero API cost")
+    ap.add_argument("--source", help="override the source carried from run_source.py")
+    ap.add_argument(
+        "--reps",
+        type=int,
+        default=None,
+        help="override num_replicates for this stage (default: config's 3)",
+    )
+    args = ap.parse_args()
+
+    if args.stage:
+        cmd_stage(args.stage, args.dry_run, args.source, args.reps)
+    elif args.select:
+        cmd_select(args.select[0], args.select[1])
+    elif args.finalize:
+        cmd_finalize()
+    else:
+        ap.error("one of --stage / --select / --finalize is required")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this is

The remaining **pipeline stages** — the walkup (step 2), mode (step 3), and order (step 4) runners, plus their figures. Stacked on #29 (`cot-mcp-cleanup`) — review that first.

**Draft on purpose:** the runners are validated in dry-run only (uniform mock data — plumbing proven, all figures render, full suite 295 passed). The actual scientific output needs real API runs (source → walkup → mode → order), which is separate spend; this stays a draft until those land.

Four commits:
- `a9574c0` — `run_walkup.py` (step 2, human-gated build-up)
- `fecf9b9` — `run_mode.py` (step 3)
- `666f4a9` — `run_order.py` (step 4, new)
- `2fc842d` — walkup / mode / order figures + README order phase

## Reviewer's guide

`run_walkup` and `run_mode` are **ported from your sibling branch** onto the unified base — the logic is yours; what changed is mechanical: imports repointed to `bench_routes` / `bench_evaluator` / `bench_pipeline_common`, and scoring goes through `score_cell` (the folded evaluator) instead of the old `scorer.score_run`.

- **`run_walkup.py`** — human-gated: each `--stage` runs its candidate framings and prints the full metric panel (sub-metric n's exposed), `--select` records the human's pick, `--finalize` assembles the prompt. It never auto-selects — so `select_winner` stayed unported.
- **`run_mode.py`** — upgraded to `run_source`'s run contract (timestamped `runs/mode/<stamp>/`, archive + push, `--score-only`) so the run is preserved, not overwritten.
- **`run_order.py`** (new) — permutes `component_order` across `[O, O1..O4]` and reports the cw-recall spread (positional sensitivity). V1 applies order to the `single_call` route with the walkup's assembled texts; a cot/stepwise transplant is out of scope.
- **figures** — restored `figure_walkup_buildup` + `figure_mode_panel` (dropped in the evaluator fold) and added `figure_order_spread`, so every step state has its figure.

Each runner mirrors `run_source`: read carry → build RunSpecs → `_run_benchmark_loop` → `score_cell` → `write_state`. All four dry-run validated at $0.
