### PR TITLE
core: review follow-ups — preflight test coverage + parameterized feature stripping

### DIFF
--- a/mozzarellm/utils/prompt_factory.py
+++ b/mozzarellm/utils/prompt_factory.py
@@ -238,12 +238,18 @@ def make_cluster_analysis_system_prompt(
 FEATURE_FIELDS = ("up_features", "down_features", "phenotypic_strength")
 
 
-def strip_feature_fields(bundle_obj: dict) -> None:
-    """Remove screen-derived feature data from an evidence bundle in place."""
+def strip_feature_fields(bundle_obj: dict, fields: tuple[str, ...] = FEATURE_FIELDS) -> None:
+    """Remove screen-derived feature data from an evidence bundle in place.
+
+    fields names the per-gene feature columns to remove; the default matches
+    the standard builder output. Bundles built with custom feature_columns
+    (build_evidence_bundles) must pass their own names or those columns
+    survive the strip.
+    """
     bundle_obj.pop("feature_coherence", None)
     for gene in bundle_obj.get("cluster_genes", []):
         if isinstance(gene, dict):
-            for field in FEATURE_FIELDS:
+            for field in fields:
                 gene.pop(field, None)
 
 

--- a/tests/test_llm_api_clients.py
+++ b/tests/test_llm_api_clients.py
@@ -79,3 +79,50 @@ def test_capability_lookup_falls_back_offline():
         assert llm._model_supports_enabled_thinking("claude-sonnet-5", None) is False
         assert llm._model_supports_enabled_thinking("claude-sonnet-4-5", None) is True
     llm._THINKING_SUPPORT_CACHE.clear()
+
+def test_resolved_params_records_the_full_outcome():
+    c = _client(
+        "claude-sonnet-5", temperature=0.2, top_p=0.9, top_k=40,
+        stop_sequences=["END"], thinking=False,
+    )
+    c._resolve_params()
+    assert c.resolved_params == {
+        "sent": {"stop_sequences": ["END"]},
+        "dropped": ["temperature", "top_p", "top_k"],
+        "thinking": "disabled",
+    }
+
+
+def test_resolution_happens_once_and_is_stable():
+    c = _client("claude-sonnet-4-5", temperature=0.2)
+    assert c._sampling_kwargs()["temperature"] == 0.2
+    c.temperature = 0.9  # post-resolution mutation must not change what is sent
+    assert c._sampling_kwargs()["temperature"] == 0.2
+    assert c.resolved_params["sent"]["temperature"] == 0.2
+
+
+def test_thinking_capability_lookup_is_cached_per_model():
+    llm._THINKING_SUPPORT_CACHE.clear()
+    calls = []
+
+    class _Models:
+        def retrieve(self, model):
+            calls.append(model)
+            return SimpleNamespace(
+                capabilities={"thinking": {"types": {"enabled": {"supported": True}}}}
+            )
+
+    with patch.object(llm.anthropic, "Anthropic", return_value=SimpleNamespace(models=_Models())):
+        assert llm._model_supports_enabled_thinking("claude-sonnet-4-5", "k") is True
+        assert llm._model_supports_enabled_thinking("claude-sonnet-4-5", "k") is True
+    assert calls == ["claude-sonnet-4-5"]
+    llm._THINKING_SUPPORT_CACHE.clear()
+
+
+def test_enabled_thinking_budget_stays_within_max_tokens():
+    with patch.object(llm, "_model_supports_enabled_thinking", return_value=True):
+        c = _client("claude-sonnet-4-5", thinking=True, max_tokens=1500)
+        budget = c._thinking_kwarg()["thinking"]["budget_tokens"]
+    assert 1024 <= budget < 1500
+    assert c.resolved_params["thinking"] == "enabled"
+

--- a/tests/test_prompt_factory_features.py
+++ b/tests/test_prompt_factory_features.py
@@ -186,3 +186,19 @@ def test_batch_request_source_gate(tmp_path):
     assert "aff text" in _bundle_text(aff) and "uni text" not in _bundle_text(aff)
     assert "flagged" in _bundle_text(aff) and "flagged" not in _bundle_text(uni)
 
+def test_strip_feature_fields_accepts_custom_field_names():
+    # Bundles built with custom feature_columns carry those names per gene;
+    # the strip must take the field set as a parameter or they would leak.
+    bundle = {
+        "cluster_genes": [
+            {"gene_symbol": "G1", "my_morphology_score": "1.2", "up_features": "cell_x"}
+        ]
+    }
+    strip_feature_fields(bundle)  # default set: custom column survives (the documented boundary)
+    assert bundle["cluster_genes"][0]["my_morphology_score"] == "1.2"
+    assert "up_features" not in bundle["cluster_genes"][0]
+
+    bundle2 = {"cluster_genes": [{"gene_symbol": "G1", "my_morphology_score": "1.2"}]}
+    strip_feature_fields(bundle2, fields=("my_morphology_score",))
+    assert "my_morphology_score" not in bundle2["cluster_genes"][0]
+


### PR DESCRIPTION
## What this is

The review follow-ups from the #25–#27 merge round, delivered as their own reviewable unit — one commit per comment:

- `6cf3349` — **preflight unit-test coverage** ([#25 review](https://github.com/cheeseman-lab/mozzarellm/pull/25#pullrequestreview-comment)): the full `resolved_params` record (sent/dropped/thinking), resolve-once stability under post-resolution mutation, one Models-API lookup per model (capability cache), and the enabled-thinking budget bounds. Tests only, no behavior change.
- `9017dcf` — **parameterized feature stripping** ([#26 comment](https://github.com/cheeseman-lab/mozzarellm/pull/26#discussion_r3796548914)): `strip_feature_fields(bundle, fields=...)` per your design — field names flow from `build_evidence_bundles(feature_columns=...)`, so the strip takes the field set as a parameter (default = the standard builder output) instead of matching three fixed names. Includes a test showing the custom-column boundary both ways.

The third comment from the round — the batch-path source gate on #27 — was fixed pre-merge in `8095135` (threaded per-request like `include_features`, regression-tested).

## Validation
Full suite at tip: 399 passed. Reviewer's guide: read `9017dcf`'s prompt_factory diff first (11 lines); everything else is tests.
