### PR TITLE
benchmark: staged experiments + the walkup

### DIFF
--- a/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_experiment.py
+++ b/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_experiment.py
@@ -13,12 +13,22 @@ and are never overwritten. ``score_only`` re-scores the newest archived run dir
 per condition without API calls; ``dry_run`` exercises the full plumbing on
 mock outputs.
 
-``stages:`` and ``uses:`` are reserved schema keys for staged experiments (the
-walkup); the loader rejects them until that PR lands.
+STAGED experiments (the walkup) replace the static ``conditions:`` with a
+``stages:`` block; each stage generates its conditions at runtime -- ``prior``
+(the carried build read from the experiment's own state) plus the stage's
+candidates. A stage is an INVOCATION, not an experiment: ``stage="CAT"`` runs
+exactly one stage, upserts its record into the experiment state, and STOPS --
+the human gate. ``select=("CAT", "process_guarded")`` records the choice and
+carries the winning text forward; recording the last stage's choice assembles
+the final build into ``carry``. ``uses: <experiment>.carry.<key>`` resolves a
+cross-experiment input (the walkup's evidence source) from that experiment's
+state file; every staged invocation logs and snapshots its resolved inputs.
 
 Usage:
     python -m tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_experiment \
         tests/phase1_prompt_benchmarking/experiments/source.yaml [--dry-run | --score-only]
+    ... bench_experiment experiments/walkup.yaml --stage CAT [--source affinage]
+    ... bench_experiment experiments/walkup.yaml --select CAT process_guarded
 """
 
 from __future__ import annotations
@@ -93,7 +103,9 @@ ABSTAIN_COHERENCE = "Low"
 # Keys a condition may set; anything a condition sets overrides the shared
 # ``run:`` block for that condition only.
 _CONDITION_KEYS = {"name", "bundle_source", "route", "component_overrides"}
-_RESERVED_KEYS = ("stages", "uses")
+# ``uses: <experiment>.carry.<key>`` -- a cross-experiment input, resolved from
+# that experiment's state file at invocation.
+_USES_RE = re.compile(r"^(?P<experiment>\w+)\.carry\.(?P<key>\w+)$")
 
 
 def load_experiment(yaml_path: Path) -> dict:
@@ -103,13 +115,20 @@ def load_experiment(yaml_path: Path) -> dict:
         raise FileNotFoundError(f"Experiment yaml not found: {yaml_path}")
     raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
 
-    for key in _RESERVED_KEYS:
-        if key in raw:
-            raise ValueError(
-                f"{yaml_path.name}: '{key}:' is reserved for staged experiments, "
-                "which arrive with the walkup PR"
-            )
-    for key in ("experiment", "model", "run", "conditions", "selection"):
+    staged = "stages" in raw
+    if staged and "conditions" in raw:
+        raise ValueError(
+            f"{yaml_path.name}: an experiment declares 'stages:' or 'conditions:', never both"
+        )
+    if not staged and "uses" in raw:
+        raise ValueError(
+            f"{yaml_path.name}: 'uses:' applies to staged experiments; stage-less "
+            "conditions declare their inputs (bundle_source) directly"
+        )
+    required = ("experiment", "model", "run") + (
+        ("stages",) if staged else ("conditions", "selection")
+    )
+    for key in required:
         if key not in raw:
             raise ValueError(f"{yaml_path.name}: missing required key '{key}:'")
 
@@ -119,6 +138,10 @@ def load_experiment(yaml_path: Path) -> dict:
             f"{yaml_path.name}: run.route {route!r} not in registry "
             f"{sorted(ROUTE_REGISTRY)}"
         )
+
+    if staged:
+        _validate_stages(yaml_path.name, raw, route)
+        return raw
 
     names = []
     for cond in raw["conditions"]:
@@ -146,6 +169,50 @@ def load_experiment(yaml_path: Path) -> dict:
                 f"allowed: {list(SELECTION_METRICS)}"
             )
     return raw
+
+
+def _validate_stages(yaml_name: str, raw: dict, route: str) -> None:
+    """Schema checks for a staged experiment's uses/stages blocks."""
+    uses = raw.get("uses")
+    if uses is not None and not _USES_RE.match(uses):
+        raise ValueError(
+            f"{yaml_name}: uses {uses!r} must be '<experiment>.carry.<key>'"
+        )
+    components = []
+    for stage in raw["stages"]:
+        for key in ("component", "goal", "candidates"):
+            if key not in stage:
+                raise ValueError(
+                    f"{yaml_name}: stage {stage.get('component')!r} missing '{key}'"
+                )
+        if stage["component"] not in ROUTE_REGISTRY[route].component_order:
+            raise ValueError(
+                f"{yaml_name}: stage component {stage['component']!r} is not a "
+                f"prompt slot of route {route!r}"
+            )
+        if stage["goal"] not in SELECTION_METRICS:
+            raise ValueError(
+                f"{yaml_name}: stage {stage['component']!r} goal {stage['goal']!r} "
+                f"not in {list(SELECTION_METRICS)}"
+            )
+        ids = []
+        for cand in stage["candidates"]:
+            for key in ("id", "rationale", "text"):
+                if not cand.get(key):
+                    raise ValueError(
+                        f"{yaml_name}: stage {stage['component']!r} candidate "
+                        f"{cand.get('id')!r} missing '{key}' (every candidate "
+                        "carries its rationale)"
+                    )
+            ids.append(cand["id"])
+        if "prior" in ids or len(ids) != len(set(ids)):
+            raise ValueError(
+                f"{yaml_name}: stage {stage['component']!r} candidate ids must be "
+                f"unique and not 'prior'; got {ids}"
+            )
+        components.append(stage["component"])
+    if len(components) != len(set(components)):
+        raise ValueError(f"{yaml_name}: duplicate stage components in {components}")
 
 
 # =============================================================================
@@ -317,16 +384,19 @@ def panel_json(p: MetricPanel) -> dict:
     }
 
 
-def _condition_config(exp: dict, cond: dict, stamp: str, dry_run: bool) -> BenchmarkConfig:
-    """BenchmarkConfig for one condition: shared blocks + the condition's overrides.
+def _condition_config(
+    exp: dict, label: str, bundle_source: str, stamp: str, dry_run: bool
+) -> BenchmarkConfig:
+    """BenchmarkConfig for one invocation: the yaml's shared blocks + its inputs.
 
+    label is the condition name (stage-less) or the stage component (staged).
     experiment_id carries the run stamp: with overwrite_outputs the resolved dir
-    (OUTPUTS/<experiment>/<condition>_<stamp>) is stable across accesses AND
-    unique per run, so previous runs archive in place and nothing is wiped.
+    (OUTPUTS/<experiment>/<label>_<stamp>) is stable across accesses AND unique
+    per run, so previous runs archive in place and nothing is wiped.
     """
     model, run = exp["model"], exp["run"]
     cfg = BenchmarkConfig()
-    cfg.experiment_id = f"{cond['name']}_{stamp}"
+    cfg.experiment_id = f"{label}_{stamp}"
     cfg.model = ModelConfig(
         provider=model.get("provider", cfg.model.provider),
         model_name=model["model_name"],
@@ -347,7 +417,7 @@ def _condition_config(exp: dict, cond: dict, stamp: str, dry_run: bool) -> Bench
         benchmark_clusters_csv=CLUSTERS_ALL,
         evidence_bundles_dir=BUNDLES_DIR,
         output_dir=OUTPUTS / exp["experiment"],
-        bundle_source=cond["bundle_source"],
+        bundle_source=bundle_source,
     )
     return cfg
 
@@ -364,19 +434,40 @@ def run_experiment(
     select: tuple[str, str] | None = None,
     dry_run: bool = False,
     score_only: bool = False,
+    source: str | None = None,
 ) -> dict:
     """Run every condition an experiment yaml declares, score, select, write state.
 
-    stage/select serve staged experiments (walkup PR); on a stage-less
-    experiment they raise cleanly. score_only re-scores the newest archived run
-    dir per condition without API calls and rewrites state.
+    Stage-less experiments run all conditions and apply the yaml's selection
+    rule. On a staged experiment, ``stage`` runs exactly one stage and stops at
+    the human gate; ``select`` records the human's choice for a stage (candidate
+    id or "prior"); ``source`` overrides the ``uses:``-resolved evidence source
+    (the stale-carry guard). Each of the three raises cleanly on the other kind
+    of experiment. score_only re-scores the newest archived run dir(s) without
+    API calls and rewrites state.
     """
     exp = load_experiment(yaml_path)
     name = exp["experiment"]
+    if "stages" in exp:
+        if select is not None:
+            if stage is not None:
+                raise ValueError("pass stage= or select=, not both")
+            return _record_selection(exp, tuple(select))
+        if stage is None:
+            raise ValueError(
+                f"experiment {name!r} is staged: pass stage=<component> to run "
+                "one stage, or select=(stage, choice) to record a gate decision"
+            )
+        return _run_stage(exp, stage, dry_run=dry_run, score_only=score_only, source=source)
     if stage is not None or select is not None:
         raise ValueError(
             f"experiment {name!r} declares no stages; stage/select apply to "
-            "staged experiments only (walkup PR)"
+            "staged experiments only"
+        )
+    if source is not None:
+        raise ValueError(
+            f"experiment {name!r} is stage-less; its conditions declare "
+            "bundle_source directly (source= overrides a staged 'uses:' input)"
         )
 
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -400,7 +491,7 @@ def run_experiment(
                     f"score_only: no archived run dir {OUTPUTS / name}/{cond_name}_<stamp>/"
                 )
         else:
-            cfg = _condition_config(exp, cond, stamp, dry_run)
+            cfg = _condition_config(exp, cond_name, cond["bundle_source"], stamp, dry_run)
             overrides = {**shared_overrides, **(cond.get("component_overrides") or {})}
             specs = [
                 RunSpec(
@@ -468,6 +559,204 @@ def run_experiment(
     return state
 
 
+# =============================================================================
+# STAGED EXPERIMENTS
+# =============================================================================
+
+
+def _resolve_uses(uses: str) -> str:
+    """Resolve '<experiment>.carry.<key>' from that experiment's state file."""
+    m = _USES_RE.match(uses)
+    src_name, key = m["experiment"], m["key"]
+    state_path = OUTPUTS / src_name / f"{src_name}_state.json"
+    if not state_path.exists():
+        raise FileNotFoundError(f"uses {uses!r}: no state file at {state_path}")
+    value = json.loads(state_path.read_text()).get("carry", {}).get(key)
+    if not value:
+        raise ValueError(f"uses {uses!r}: {state_path.name} carries no {key!r}")
+    return value
+
+
+def _staged_state(exp: dict) -> tuple[dict, Path]:
+    """Load (or initialise) a staged experiment's state; carried starts all-blank.
+
+    The all-blank carried dict IS the blank W0 floor: every stage component is
+    overridden to "" until a stage's selection fills it.
+    """
+    name = exp["experiment"]
+    order = [s["component"] for s in exp["stages"]]
+    path = OUTPUTS / name / f"{name}_state.json"
+    if path.exists():
+        return json.loads(path.read_text()), path
+    return {
+        "experiment": name,
+        "uses": exp.get("uses"),
+        "source": None,
+        "order": order,
+        "carried": dict.fromkeys(order, ""),
+        "stages": [],
+    }, path
+
+
+def _save_staged_state(state: dict, path: Path) -> None:
+    state["components_filled"] = [c for c in state["order"] if state["carried"].get(c)]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2))
+    print(f"\nstate -> {path}")
+
+
+def _run_stage(
+    exp: dict, stage: str, *, dry_run: bool, score_only: bool, source: str | None
+) -> dict:
+    """Run one stage's conditions (prior + candidates), score, upsert, STOP.
+
+    Selection is deliberately absent: several goal metrics are too low-powered
+    on this benchmark to trust an automatic rule, so each stage ends at a human
+    gate -- the panels land in the state file and a person records the choice
+    via select=.
+    """
+    name = exp["experiment"]
+    spec = next((s for s in exp["stages"] if s["component"] == stage), None)
+    if spec is None:
+        raise ValueError(
+            f"unknown stage {stage!r}; stages: {[s['component'] for s in exp['stages']]}"
+        )
+    state, state_path = _staged_state(exp)
+
+    # Resolve the evidence source once per experiment: explicit override, else
+    # the source earlier stages ran on, else the uses: input. A mid-experiment
+    # switch would mix evidence regimes across stages, so it is refused.
+    resolved = source or state.get("source")
+    if resolved is None and exp.get("uses"):
+        resolved = _resolve_uses(exp["uses"])
+    if resolved is None:
+        raise ValueError(f"{name}: no evidence source (declare uses: or pass source=)")
+    if state["stages"] and state.get("source") and resolved != state["source"]:
+        raise ValueError(
+            f"{name}: stages already ran on source={state['source']!r}; refusing "
+            f"to run {stage} on {resolved!r}"
+        )
+    state["source"] = resolved
+
+    carried = state["carried"]
+    filled = [c for c in state["order"] if carried.get(c)]
+    print(
+        f"[{name}] stage {stage} on source={resolved}; "
+        f"carried build: {'+'.join(filled) if filled else 'blank W0'}"
+    )
+
+    gt, coh = load_gt_and_coherence()
+    controls = validation_specs(gt)
+    route_name = exp["run"]["route"]
+    conditions = {f"{stage}_prior": dict(carried)}
+    for cand in spec["candidates"]:
+        conditions[f"{stage}_{cand['id']}"] = {**carried, stage: cand["text"]}
+
+    if score_only:
+        out = latest_run_dir(name, stage)
+        if out is None:
+            raise FileNotFoundError(
+                f"score_only: no archived run dir {OUTPUTS / name}/{stage}_<stamp>/"
+            )
+        stamp = None
+    else:
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        cfg = _condition_config(exp, stage, resolved, stamp, dry_run)
+        specs = [
+            RunSpec(
+                route=ROUTE_REGISTRY[route_name],
+                condition_name=label,
+                component_overrides=overrides,
+            )
+            for label, overrides in conditions.items()
+        ]
+        snapshot = _build_config_snapshot(
+            cfg,
+            experiment={
+                "experiment": name,
+                "stage": stage,
+                "goal": spec["goal"],
+                "source": resolved,
+                "carried_components": filled,
+            },
+        )
+        print(f"[{name}] {len(conditions)} conditions -> {cfg.experiment_output_dir}")
+        _run_benchmark_loop(cfg, specs, snapshot, phase_label=f"{name}:{stage}")
+        out = cfg.experiment_output_dir
+
+    def _abstain(label: str) -> str:
+        rows = decoy_results(out, label, controls)
+        return f"{sum(1 for d in rows if d['passed'])}/{len(rows)}"
+
+    panels = {
+        label: score_run(out, gt, cluster_coherence=coh, route_equals=label)
+        for label in conditions
+    }
+    record = {
+        "stage": stage,
+        "goal": spec["goal"],
+        "run_dir": out.name,
+        "resolved": {"source": resolved, "carried_components": filled},
+        "prior": panel_json(panels[f"{stage}_prior"]),
+        "prior_abstain": _abstain(f"{stage}_prior"),
+        "candidates": {
+            cand["id"]: panel_json(panels[f"{stage}_{cand['id']}"])
+            for cand in spec["candidates"]
+        },
+        "candidate_abstain": {
+            cand["id"]: _abstain(f"{stage}_{cand['id']}") for cand in spec["candidates"]
+        },
+        "selected": None,
+    }
+    state["stages"] = [s for s in state["stages"] if s["stage"] != stage]
+    state["stages"].append(record)
+    state["stages"].sort(key=lambda s: state["order"].index(s["stage"]))
+    _save_staged_state(state, state_path)
+    print(f"[{name}] gate: record the choice with select=({stage!r}, <candidate|'prior'>)")
+    return state
+
+
+def _record_selection(exp: dict, select: tuple[str, str]) -> dict:
+    """Record the human gate decision for a stage; finalize after the last one.
+
+    The chosen candidate's text (or "" for prior) becomes the carried build for
+    every later stage. When every stage has a recorded choice, the final build
+    is assembled into ``carry`` for the next step to consume.
+    """
+    stage, choice = select
+    name = exp["experiment"]
+    spec = next((s for s in exp["stages"] if s["component"] == stage), None)
+    if spec is None:
+        raise ValueError(
+            f"unknown stage {stage!r}; stages: {[s['component'] for s in exp['stages']]}"
+        )
+    state, state_path = _staged_state(exp)
+    record = next((s for s in state["stages"] if s["stage"] == stage), None)
+    if record is None:
+        raise ValueError(f"stage {stage!r} has not been run yet (pass stage={stage!r} first)")
+    texts = {cand["id"]: cand["text"] for cand in spec["candidates"]}
+    if choice != "prior" and choice not in texts:
+        raise ValueError(f"unknown candidate {choice!r}; options: {['prior', *texts]}")
+    record["selected"] = choice
+    state["carried"][stage] = "" if choice == "prior" else texts[choice]
+
+    chosen = {s["stage"] for s in state["stages"] if s["selected"]}
+    if chosen == set(state["order"]):
+        filled = [c for c in state["order"] if state["carried"].get(c)]
+        state["winner"] = "+".join(filled) if filled else "blank_W0"
+        state["carry"] = {
+            "source": state["source"],
+            "components_filled": filled,
+            "final_component_texts": {k: v for k, v in state["carried"].items() if v},
+        }
+        print(f"[{name}] all stages chosen; final build: {state['winner']}")
+    else:
+        pending = [c for c in state["order"] if c not in chosen]
+        print(f"[{name}] recorded {stage} <- {choice}; next stage: {pending[0]}")
+    _save_staged_state(state, state_path)
+    return state
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("yaml_path", type=Path, help="experiment yaml (e.g. experiments/source.yaml)")
@@ -475,8 +764,23 @@ def main() -> None:
     ap.add_argument(
         "--score-only", action="store_true", help="re-score newest archived run dirs, no API calls"
     )
+    ap.add_argument("--stage", help="staged experiments: run one stage's candidates and stop")
+    ap.add_argument(
+        "--select",
+        nargs=2,
+        metavar=("STAGE", "CHOICE"),
+        help="staged experiments: record the human gate decision (candidate id or 'prior')",
+    )
+    ap.add_argument("--source", help="staged experiments: override the uses:-resolved source")
     args = ap.parse_args()
-    run_experiment(args.yaml_path, dry_run=args.dry_run, score_only=args.score_only)
+    run_experiment(
+        args.yaml_path,
+        stage=args.stage,
+        select=tuple(args.select) if args.select else None,
+        dry_run=args.dry_run,
+        score_only=args.score_only,
+        source=args.source,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/phase1_prompt_benchmarking/experiments/walkup.yaml
+++ b/tests/phase1_prompt_benchmarking/experiments/walkup.yaml
@@ -1,0 +1,341 @@
+# The walkup experiment: build the prompt up from the blank W0 floor, one
+# component per stage (CAT -> GCR -> NPR -> UPR -> PCC), on the evidence source
+# the source experiment carried. Each stage runs 'prior' (the carried build)
+# plus the candidates below and stops at the human gate; a person records the
+# choice (candidate id or 'prior') under the walkup contract -- the stage's goal
+# metric must improve beyond noise with the other panel metrics held.
+#
+# Candidate texts are the experiment's material and live here, with their
+# rationales; engineered candidates (from miss censuses) are yaml edits with
+# their rationale, committed and visible in history. Directions informed by the
+# first flat run: GCR/NPR/PCC test validated ladders (simple -> +procedure ->
+# +guard); CAT tests distinct task lenses plus the two engineered process-frame
+# candidates; UPR candidates are all corrections (the v6 rules over-demoted
+# named/annotated genes toward DARK_GENE).
+
+experiment: walkup
+description: build-up prompt walkup on the carried evidence source, human-gated per stage
+
+uses: source.carry.source
+
+model:
+  provider: anthropic
+  model_name: claude-sonnet-5
+  # temperature omitted: claude-sonnet-5 rejects non-default sampling params
+  max_tokens: 16000
+  thinking: false
+
+run:
+  replicates: 3
+  max_workers: 12
+  route: single_call
+
+stages:
+  - component: CAT
+    goal: category
+    candidates:
+      - id: concise
+        rationale: >-
+          lean task statement (multi-pathway-aware) -- tests whether the elaboration
+          grounds the model or just spends tokens
+        text: |
+          MISSION: Analyze this gene cluster and:
+          1. Identify the biological pathway(s) — a single dominant process, or 2-3 if the cluster genuinely
+             spans several — that explain why these genes cluster together.
+          2. Categorize ALL genes as ESTABLISHED (known role in the pathway), NOVEL_ROLE (characterized
+             elsewhere), or UNCHARACTERIZED (no focused study).
+          3. Prioritize NOVEL_ROLE and UNCHARACTERIZED genes for follow-up.
+
+      - id: discovery_first
+        rationale: >-
+          lead with the recall-first mission + honest 'no coherent pathway' from the very
+          first component (multi-pathway-aware)
+        text: |
+          MISSION: Functional genomics experiments cluster genes by phenotypic similarity. The deliverable is
+          to surface UNDERSTUDIED genes (UNCHARACTERIZED and NOVEL_ROLE) that merit experimental follow-up.
+          To do that:
+          1. Identify the pathway(s) that best explain why these genes cluster — a single dominant process, or
+             2-3 if the cluster genuinely spans several. This is the lens for discovery, not the end goal.
+          2. Categorize ALL genes relative to that pathway (ESTABLISHED / NOVEL_ROLE / UNCHARACTERIZED).
+          3. Prioritize the understudied genes for follow-up.
+
+          If the genes do not share a coherent pathway, say so honestly rather than forcing a label — a clear
+          "no coherent pathway" call is a valid and useful outcome.
+
+      - id: pathway_anchored
+        rationale: >-
+          anchor on rigorously fixing the pathway(s) first, since every downstream call
+          depends on it (multi-pathway-aware)
+        text: |
+          MISSION: Every downstream call depends on correctly identifying what unites this cluster, so anchor
+          there first.
+          1. Determine the biological pathway(s) that explain the cluster — commit to a single dominant
+             process where one clearly fits, or 2-3 distinct processes if the cluster genuinely spans them. If
+             no process explains a substantial share of the genes, declare no coherent pathway.
+          2. Categorize ALL genes against that pathway (ESTABLISHED / NOVEL_ROLE / UNCHARACTERIZED).
+          3. Prioritize UNCHARACTERIZED and NOVEL_ROLE genes for follow-up.
+
+      - id: process_relative
+        rationale: >-
+          engineered from the W0 miss census (all 6 misses are NOVEL leaks): pin the
+          categorization reference frame to the cluster's pathway -- a documented gene with
+          no documented link to THIS pathway is NOVEL_ROLE not ESTABLISHED, a sparse gene
+          whose evidence threads to the pathway is NOVEL_ROLE not UNCHARACTERIZED
+        text: |
+          MISSION: Functional genomics experiments cluster genes by phenotypic similarity. Your goal is to:
+          1. Identify the dominant biological pathway(s) that explain why these genes cluster together — or
+             declare no coherent pathway if none explains a substantial share of the genes.
+          2. Categorize EVERY gene by its relationship to THAT pathway, never by how well the gene is
+             characterized overall:
+             - ESTABLISHED: the gene has a documented role in this cluster's pathway
+             - NOVEL_ROLE: the gene is documented, but a role in this cluster's pathway is not — its
+               membership here is the new evidence
+             - UNCHARACTERIZED: annotation is too sparse to judge any relationship
+             A well-studied gene with no documented link to this pathway is NOVEL_ROLE, not ESTABLISHED. A
+             sparsely annotated gene whose evidence still threads to this pathway is NOVEL_ROLE, not
+             UNCHARACTERIZED.
+          3. Prioritize understudied genes (UNCHARACTERIZED and NOVEL_ROLE) for follow-up experiments.
+
+          The pathway is not the end goal - it's the reference frame for deciding which genes merit
+          investigation.
+
+      - id: process_guarded
+        rationale: >-
+          round-2 engineering: process_relative fixed the fame leak (novel recall
+          .857->.929) but over-rotated 5 in-pathway genes to NOVEL (SCD/SREBF2/GPAT4 in the
+          lipid cluster); adds the symmetric guard -- check the annotation for the pathway
+          itself before NOVEL_ROLE, and reserve UNCHARACTERIZED for annotation that offers
+          nothing to relate
+        text: |
+          MISSION: Functional genomics experiments cluster genes by phenotypic similarity. Your goal is to:
+          1. Identify the dominant biological pathway(s) that explain why these genes cluster together — or
+             declare no coherent pathway if none explains a substantial share of the genes.
+          2. Categorize EVERY gene by its relationship to THAT pathway, using this two-way test:
+             - First check the gene's annotation FOR THE PATHWAY ITSELF: if its documented function is part
+               of this cluster's pathway, it is ESTABLISHED — however famous or obscure the gene.
+             - Only if its documented function is genuinely distinct from this pathway is it NOVEL_ROLE —
+               membership here is the new evidence. General fame never makes a gene ESTABLISHED.
+             - UNCHARACTERIZED is reserved for genes whose annotation offers nothing to relate; if any
+               functional annotation exists, decide between ESTABLISHED and NOVEL_ROLE relative to the
+               pathway.
+          3. Prioritize understudied genes (UNCHARACTERIZED and NOVEL_ROLE) for follow-up experiments.
+
+          The pathway is not the end goal - it's the reference frame for deciding which genes merit
+          investigation.
+
+  - component: GCR
+    goal: category
+    candidates:
+      - id: simple
+        rationale: definitions only -- baseline categorization rules
+        text: |
+          PRECONDITION: This step applies ONLY when a coherent biological pathway has been identified for the cluster. If no coherent pathway exists, leave `established_genes`, `novel_role_genes`, and `uncharacterized_genes` empty and skip this step — per-gene classification relative to a nonexistent pathway is undefined.
+
+          TASK: For each gene in the cluster, categorize as ESTABLISHED, NOVEL_ROLE, or UNCHARACTERIZED based on the evidence provided in the gene's bundle annotation.
+          - ESTABLISHED: the annotation directly demonstrates the gene's role in the identified pathway.
+          - NOVEL_ROLE: the annotation describes a documented function in a different pathway.
+          - UNCHARACTERIZED: the annotation is empty, generic, or limited to homology/domain information.
+
+      - id: decision_tree
+        rationale: ordered gating procedure cuts category ambiguity -- the first-run winner
+        text: |
+          PRECONDITION: This step applies ONLY when a coherent biological pathway has been identified for the cluster. If no coherent pathway exists, leave `established_genes`, `novel_role_genes`, and `uncharacterized_genes` empty and skip this step — per-gene classification relative to a nonexistent pathway is undefined.
+
+          TASK: For each gene in the cluster, categorize as ESTABLISHED, NOVEL_ROLE, or UNCHARACTERIZED based on the evidence provided in the gene's bundle annotation.
+          - ESTABLISHED: the annotation directly demonstrates the gene's role in the identified pathway.
+          - NOVEL_ROLE: the annotation describes a documented function in a different pathway.
+          - UNCHARACTERIZED: the annotation is empty, generic, or limited to homology/domain information.
+
+          Gating procedure (apply in order):
+          1. Does the bundle's annotation describe the gene's molecular function? → No → UNCHARACTERIZED.
+          2. Does that annotation describe a role in THIS pathway? → Yes → ESTABLISHED.
+          3. Otherwise → NOVEL_ROLE.
+
+      - id: guarded
+        rationale: >-
+          decision-tree + default-to-NOVEL-when-uncertain -- anti-overcrediting,
+          recall-first
+        text: |
+          PRECONDITION: This step applies ONLY when a coherent biological pathway has been identified for the cluster. If no coherent pathway exists, leave `established_genes`, `novel_role_genes`, and `uncharacterized_genes` empty and skip this step — per-gene classification relative to a nonexistent pathway is undefined.
+
+          TASK: For each gene in the cluster, categorize as ESTABLISHED, NOVEL_ROLE, or UNCHARACTERIZED based on the evidence provided in the gene's bundle annotation.
+          - ESTABLISHED: the annotation directly demonstrates the gene's role in the identified pathway.
+          - NOVEL_ROLE: the annotation describes a documented function in a different pathway.
+          - UNCHARACTERIZED: the annotation is empty, generic, or limited to homology/domain information.
+
+          Gating procedure (apply in order):
+          1. Does the bundle's annotation describe the gene's molecular function? → No → UNCHARACTERIZED.
+          2. Does that annotation describe a role in THIS pathway? → Yes → ESTABLISHED.
+          3. Otherwise → NOVEL_ROLE.
+
+          When uncertain whether the bundle's evidence rises to the ESTABLISHED standard, default to NOVEL_ROLE — promoting on weak or indirect evidence misleads downstream follow-up.
+
+  - component: NPR
+    goal: novel_subclass
+    candidates:
+      - id: simple
+        rationale: flat NO/INDIRECT/PARTIAL/CONTRADICTORY definitions -- baseline
+        text: |
+          PRECONDITION: This step applies ONLY to genes already categorized as NOVEL_ROLE per the gene classification rules. If no genes were categorized as NOVEL_ROLE (because no coherent pathway exists, or no genes fit the criteria), do nothing — no sub-classification is needed.
+
+          SUB-CLASSIFICATION (NOVEL_ROLE genes only): assign exactly one sub-class based on how the bundle's annotation relates to the identified pathway.
+          - NO_EVIDENCE: nothing in the annotation links the gene to this pathway.
+          - INDIRECT_EVIDENCE: the annotation shows a logical connection (shared organelle, upstream regulator) but no direct experimental link.
+          - PARTIAL_EVIDENCE: the annotation hints at a link (proteomics hit, co-expression) without focused mechanistic study.
+          - CONTRADICTORY_EVIDENCE: the annotation describes a function incompatible with this pathway.
+
+      - id: decision_tree
+        rationale: ordered procedure over the four evidence levels -- first-run winner
+        text: |
+          PRECONDITION: This step applies ONLY to genes already categorized as NOVEL_ROLE per the gene classification rules. If no genes were categorized as NOVEL_ROLE (because no coherent pathway exists, or no genes fit the criteria), do nothing — no sub-classification is needed.
+
+          SUB-CLASSIFICATION (NOVEL_ROLE genes only): assign exactly one sub-class based on how the bundle's annotation relates to the identified pathway.
+          - NO_EVIDENCE: nothing in the annotation links the gene to this pathway.
+          - INDIRECT_EVIDENCE: the annotation shows a logical connection (shared organelle, upstream regulator) but no direct experimental link.
+          - PARTIAL_EVIDENCE: the annotation hints at a link (proteomics hit, co-expression) without focused mechanistic study.
+          - CONTRADICTORY_EVIDENCE: the annotation describes a function incompatible with this pathway.
+
+          Procedure (apply in order):
+          1. Does the annotation describe a function incompatible with this pathway? → CONTRADICTORY_EVIDENCE.
+          2. Does the annotation hint at a preliminary link (proteomics/co-expression/correlative data)? → PARTIAL_EVIDENCE.
+          3. Does the annotation suggest a logical connection without direct experimental link? → INDIRECT_EVIDENCE.
+          4. Otherwise → NO_EVIDENCE.
+
+      - id: process_scoped
+        rationale: >-
+          two-sided, diagnostic-driven: the model's dominant error is INDIRECT
+          under-credited to NO (chromatin/RNA genes in chromatin/RNA clusters), but a
+          blanket 'shared context = INDIRECT' overshot -- collapsed correct PARTIAL genes
+          and over-promoted unrelated NO genes. Reframes NO/INDIRECT as
+          unrelated-vs-same-process AND guards PARTIAL (data touching the pathway stays
+          PARTIAL) and NO (a shared generic compartment is not same-process)
+        text: |
+          PRECONDITION: This step applies ONLY to genes already categorized as NOVEL_ROLE per the gene classification rules. If no genes were categorized as NOVEL_ROLE (because no coherent pathway exists, or no genes fit the criteria), do nothing — no sub-classification is needed.
+
+          SUB-CLASSIFICATION (NOVEL_ROLE genes only): assign exactly one sub-class based on how the bundle's annotation relates to the identified pathway.
+          - NO_EVIDENCE: the gene's characterized function is in a process UNRELATED to this pathway.
+          - INDIRECT_EVIDENCE: the gene acts in the SAME broad process or machinery as the pathway (e.g. a chromatin factor in a chromatin/centromere cluster; an RNA-processing factor in an RNA cluster) but the annotation reports no experimental link to the specific pathway.
+          - PARTIAL_EVIDENCE: the annotation reports actual data touching this pathway — a physical interaction, proteomics/co-IP hit, co-expression, or a functional assay — but no focused mechanistic study.
+          - CONTRADICTORY_EVIDENCE: the annotation describes a function incompatible with this pathway.
+
+          Procedure (apply in order):
+          1. Does the annotation describe a function incompatible with this pathway? → CONTRADICTORY_EVIDENCE.
+          2. Does the annotation report experimental data touching this pathway (interaction, proteomics/co-IP, co-expression, functional assay)? → PARTIAL_EVIDENCE. Do NOT down-rank a gene that has such data to INDIRECT.
+          3. Does the gene operate in the same broad process or machinery as the pathway, with no such data? → INDIRECT_EVIDENCE.
+          4. Otherwise (function is in an unrelated process) → NO_EVIDENCE. Sharing only a generic compartment (e.g. "nuclear", "cytoplasmic") is NOT the same process — keep NO_EVIDENCE.
+
+  - component: UPR
+    goal: unchar_subclass
+    candidates:
+      - id: name_respecting
+        rationale: >-
+          CORRECTED: a name+domain gene is ANNOTATED_ONLY, not DARK -- undoes the v6
+          over-demotion that broke unchar-subclass
+        text: |
+          PRECONDITION: This step applies ONLY to genes already categorized as UNCHARACTERIZED per the gene
+          classification rules. If no genes were categorized as UNCHARACTERIZED, do nothing.
+
+          SUB-CLASSIFICATION (UNCHARACTERIZED genes only): assign exactly one sub-class from the gene's bundle
+          annotation. A standard gene name plus domain/motif annotation IS meaningful signal — do NOT demote a
+          named, domain-annotated gene to DARK_GENE merely because no mechanistic study exists.
+          - DARK_GENE: no standard name AND no domain/functional annotation whatsoever.
+          - NASCENT: no standard name, but the annotation contains preliminary functional data.
+          - ANNOTATED_ONLY: has a standard name and/or domain/motif annotation but no mechanistic study — this
+            is the default for named genes that lack a focused functional study.
+          - NON_HUMAN_CHARACTERIZED: the annotation describes functional studies only in non-human organisms.
+
+      - id: evidence_ladder
+        rationale: >-
+          CORRECTED: rank by the HIGHEST level of evidence actually present with no
+          downward tiebreak (the v6 'prefer lower' guard was the likely source of the
+          unchar-subclass loss)
+        text: |
+          PRECONDITION: This step applies ONLY to genes already categorized as UNCHARACTERIZED per the gene
+          classification rules. If no genes were categorized as UNCHARACTERIZED, do nothing.
+
+          SUB-CLASSIFICATION (UNCHARACTERIZED genes only): assign the sub-class matching the HIGHEST level of
+          evidence present in the annotation. Evaluate in order and assign the first that matches; do not bias
+          toward lower-information classes.
+          - NON_HUMAN_CHARACTERIZED: functional studies described only in a non-human organism.
+          - ANNOTATED_ONLY: a standard name with domain/motif annotation, no mechanistic study.
+          - NASCENT: no standard name, but some preliminary functional data present.
+          - DARK_GENE: none of the above — no name, no domain annotation, no functional data.
+
+      - id: canonical_grounded
+        rationale: >-
+          CORRECTED: revert to the canonical 4-subclass rules (scored 0.714),
+          bundle-grounded, no aggressive guard
+        text: |
+          PRECONDITION: This step applies ONLY to genes already categorized as UNCHARACTERIZED per the gene
+          classification rules. If no genes were categorized as UNCHARACTERIZED, do nothing.
+
+          SUB-CLASSIFICATION (UNCHARACTERIZED genes only): assign exactly one sub-class based on the gene's
+          bundle annotation.
+          - DARK_GENE: no name, no functional characterization whatsoever.
+          - NASCENT: no standard name, but some preliminary functional data exists.
+          - ANNOTATED_ONLY: has a gene name and domain/motif annotations, but no mechanistic study.
+          - NON_HUMAN_CHARACTERIZED: functionally studied in a non-human organism only.
+          Assign exactly one sub-class per gene.
+
+  - component: PCC
+    goal: coherence
+    candidates:
+      - id: simple
+        rationale: qualitative high/medium/low by fraction consistent -- lean
+        text: |
+          PATHWAY CONFIDENCE: assess how well the identified pathway explains the cluster, based on the fraction of genes whose bundle annotations are consistent with the pathway.
+          - High: most genes have annotations consistent with the pathway.
+          - Medium: a majority are consistent; some genes are unclear or unrelated.
+          - Low: few genes are clearly consistent — or, if too few, the cluster lacks a coherent pathway entirely (use "dominant_process": "No coherent biological pathway", and leave `established_genes`, `novel_role_genes`, and `uncharacterized_genes` empty since per-gene classification relative to a nonexistent pathway is undefined).
+
+      - id: detailed
+        rationale: explicit >70/50-70/30-50 percent thresholds per level
+        text: |
+          PATHWAY CONFIDENCE: assess how well the identified pathway explains the cluster, based on the bundle's gene annotations.
+
+          High confidence:
+          - >70% of cluster genes have annotations consistent with the pathway
+          - Multiple well-established members with direct functional evidence
+          - Clear functional relationships explain the phenotypic clustering
+
+          Medium confidence:
+          - 50-70% of cluster genes are consistent with the pathway
+          - Some established members alongside plausible additional candidates
+          - Functional relationship is plausible but has gaps
+
+          Low confidence:
+          - 30-50% of cluster genes are clearly consistent
+          - Few established members; themes may be broad or general
+          - Significant heterogeneity in gene functions
+
+          No coherent pathway (use Low confidence, set "dominant_process": "No coherent biological pathway", and leave `established_genes`, `novel_role_genes`, and `uncharacterized_genes` empty — per-gene classification relative to a nonexistent pathway is undefined):
+          - <30% of cluster genes fit any proposed pathway
+          - Cluster contains many unrelated functions or nontargeting controls
+
+      - id: guarded
+        rationale: >-
+          thresholds + prefer-lower-confidence + honest no-pathway framing -- corrects the
+          model running 'hot' on coherence
+        text: |
+          PATHWAY CONFIDENCE: assess how well the identified pathway explains the cluster, based on the bundle's gene annotations.
+
+          High confidence:
+          - >70% of cluster genes have annotations consistent with the pathway
+          - Multiple well-established members with direct functional evidence
+          - Clear functional relationships explain the phenotypic clustering
+
+          Medium confidence:
+          - 50-70% of cluster genes are consistent with the pathway
+          - Some established members alongside plausible additional candidates
+          - Functional relationship is plausible but has gaps
+
+          Low confidence:
+          - 30-50% of cluster genes are clearly consistent
+          - Few established members; themes may be broad or general
+          - Significant heterogeneity in gene functions
+
+          No coherent pathway (use Low confidence, set "dominant_process": "No coherent biological pathway", and leave `established_genes`, `novel_role_genes`, and `uncharacterized_genes` empty — per-gene classification relative to a nonexistent pathway is undefined):
+          - <30% of cluster genes fit any proposed pathway
+          - Cluster contains many unrelated functions or nontargeting controls
+
+          When uncertain between two adjacent levels, prefer the lower confidence. Flagging that a cluster lacks a coherent pathway is a valuable finding — clusters can be heterogeneous, noisy, or artifactual, and an honest "no coherent pathway" call is more useful than a forced label.

--- a/tests/test_bench_experiment.py
+++ b/tests/test_bench_experiment.py
@@ -362,3 +362,31 @@ class TestStagedInvocation:
         state = run_experiment(path, stage="CAT", dry_run=True, source="uniprot")
         assert state["source"] == "uniprot"
         assert state["stages"][0]["resolved"]["source"] == "uniprot"
+
+
+WALKUP_YAML = SOURCE_YAML.parent / "walkup.yaml"
+
+
+def test_walkup_yaml_parses_with_the_full_candidate_bank():
+    exp = load_experiment(WALKUP_YAML)
+    assert exp["uses"] == "source.carry.source"
+    stages = {s["component"]: s for s in exp["stages"]}
+    assert list(stages) == ["CAT", "GCR", "NPR", "UPR", "PCC"]
+    goals = {c: s["goal"] for c, s in stages.items()}
+    assert goals == {
+        "CAT": "category",
+        "GCR": "category",
+        "NPR": "novel_subclass",
+        "UPR": "unchar_subclass",
+        "PCC": "coherence",
+    }
+    assert {c["id"] for c in stages["CAT"]["candidates"]} == {
+        "concise",
+        "discovery_first",
+        "pathway_anchored",
+        "process_relative",
+        "process_guarded",
+    }
+    for stage in stages.values():
+        for cand in stage["candidates"]:
+            assert cand["rationale"] and cand["text"]

--- a/tests/test_bench_experiment.py
+++ b/tests/test_bench_experiment.py
@@ -64,10 +64,9 @@ class TestLoadExperiment:
         assert exp["run"]["route"] == "single_call"
         assert exp["carry"] == ["source"]
 
-    @pytest.mark.parametrize("reserved", ["stages", "uses"])
-    def test_reserved_keys_rejected_until_walkup_pr(self, tmp_path, reserved):
-        with pytest.raises(ValueError, match="reserved for staged experiments"):
-            load_experiment(_write_yaml(tmp_path, _MINIMAL_YAML + f"{reserved}: []\n"))
+    def test_uses_rejected_on_stageless_experiment(self, tmp_path):
+        with pytest.raises(ValueError, match="'uses:' applies to staged experiments"):
+            load_experiment(_write_yaml(tmp_path, _MINIMAL_YAML + "uses: source.carry.source\n"))
 
     def test_missing_required_key_rejected(self, tmp_path):
         text = _MINIMAL_YAML.replace(
@@ -230,3 +229,136 @@ def test_dry_run_of_source_experiment_writes_state(tmp_path, monkeypatch):
         assert cond in state["pathway"]
     assert "reviewer_concordance" in state
     assert "source_preference" in state
+
+
+# ---------------------------------------------------------------------------
+# Staged experiments
+# ---------------------------------------------------------------------------
+
+_STAGED_YAML = """\
+experiment: w
+model: {model_name: claude-sonnet-5}
+run: {replicates: 1, route: single_call}
+uses: source.carry.source
+stages:
+  - component: CAT
+    goal: category
+    candidates:
+      - {id: c1, rationale: test framing, text: CAT TEXT ONE}
+  - component: GCR
+    goal: category
+    candidates:
+      - {id: g1, rationale: test framing, text: GCR TEXT ONE}
+"""
+
+
+class TestStagedSchema:
+    def test_staged_yaml_parses(self, tmp_path):
+        exp = load_experiment(_write_yaml(tmp_path, _STAGED_YAML))
+        assert [s["component"] for s in exp["stages"]] == ["CAT", "GCR"]
+        assert exp["uses"] == "source.carry.source"
+
+    def test_stages_and_conditions_are_exclusive(self, tmp_path):
+        text = _STAGED_YAML + "conditions:\n  - {name: a, bundle_source: uniprot}\n"
+        with pytest.raises(ValueError, match="never both"):
+            load_experiment(_write_yaml(tmp_path, text))
+
+    def test_malformed_uses_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="must be '<experiment>.carry.<key>'"):
+            load_experiment(
+                _write_yaml(tmp_path, _STAGED_YAML.replace("source.carry.source", "source"))
+            )
+
+    def test_stage_component_must_be_a_prompt_slot(self, tmp_path):
+        with pytest.raises(ValueError, match="not a prompt slot"):
+            load_experiment(_write_yaml(tmp_path, _STAGED_YAML.replace("component: GCR", "component: XXX")))
+
+    def test_stage_goal_must_be_a_selection_metric(self, tmp_path):
+        text = _STAGED_YAML.replace("goal: category", "goal: accuracy", 1)
+        with pytest.raises(ValueError, match="goal 'accuracy'"):
+            load_experiment(_write_yaml(tmp_path, text))
+
+    def test_candidate_id_prior_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="not 'prior'"):
+            load_experiment(_write_yaml(tmp_path, _STAGED_YAML.replace("id: c1", "id: prior")))
+
+    def test_candidate_requires_rationale(self, tmp_path):
+        text = _STAGED_YAML.replace("rationale: test framing, ", "", 1)
+        with pytest.raises(ValueError, match="missing 'rationale'"):
+            load_experiment(_write_yaml(tmp_path, text))
+
+    def test_staged_invocation_requires_stage_or_select(self, tmp_path):
+        with pytest.raises(ValueError, match="is staged"):
+            run_experiment(_write_yaml(tmp_path, _STAGED_YAML))
+
+    def test_source_override_rejected_on_stageless(self, tmp_path):
+        with pytest.raises(ValueError, match="is stage-less"):
+            run_experiment(_write_yaml(tmp_path, _MINIMAL_YAML), source="affinage")
+
+
+class TestStagedInvocation:
+    def _setup(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(bench_experiment, "OUTPUTS", tmp_path)
+        monkeypatch.setattr(bench_experiment, "GT_PATH", tmp_path / "consensus_gt.csv")
+        (tmp_path / "source").mkdir()
+        (tmp_path / "source" / "source_state.json").write_text(
+            json.dumps({"carry": {"source": "affinage"}})
+        )
+        return _write_yaml(tmp_path, _STAGED_YAML)
+
+    def test_stage_runs_scores_and_stops_at_the_gate(self, tmp_path, monkeypatch):
+        path = self._setup(tmp_path, monkeypatch)
+        state = run_experiment(path, stage="CAT", dry_run=True)
+
+        assert state["source"] == "affinage"  # resolved through uses:
+        assert [s["stage"] for s in state["stages"]] == ["CAT"]  # GCR did NOT run
+        rec = state["stages"][0]
+        assert rec["resolved"] == {"source": "affinage", "carried_components": []}
+        assert rec["selected"] is None
+        assert rec["prior"]["n"] > 0 and rec["candidates"]["c1"]["n"] > 0
+        run_dir = tmp_path / "w" / rec["run_dir"]
+        assert run_dir.is_dir() and rec["run_dir"].startswith("CAT_")
+        on_disk = json.loads((tmp_path / "w" / "w_state.json").read_text())
+        assert on_disk == json.loads(json.dumps(state))
+
+    def test_select_carries_text_and_finalizes_after_last_stage(self, tmp_path, monkeypatch):
+        path = self._setup(tmp_path, monkeypatch)
+        run_experiment(path, stage="CAT", dry_run=True)
+
+        with pytest.raises(ValueError, match="has not been run yet"):
+            run_experiment(path, select=("GCR", "g1"))
+        with pytest.raises(ValueError, match="unknown candidate"):
+            run_experiment(path, select=("CAT", "nope"))
+
+        state = run_experiment(path, select=("CAT", "c1"))
+        assert state["carried"]["CAT"] == "CAT TEXT ONE"
+        assert state["components_filled"] == ["CAT"]
+        assert "carry" not in state  # GCR still pending
+
+        state = run_experiment(path, stage="GCR", dry_run=True)
+        rec = next(s for s in state["stages"] if s["stage"] == "GCR")
+        assert rec["resolved"]["carried_components"] == ["CAT"]
+        # The carried CAT text reaches the next stage's prompts.
+        prompts = (tmp_path / "w" / rec["run_dir"] / "prompts.jsonl").read_text()
+        assert "CAT TEXT ONE" in prompts
+
+        state = run_experiment(path, select=("GCR", "prior"))
+        assert state["carried"]["GCR"] == ""
+        assert state["winner"] == "CAT"
+        assert state["carry"] == {
+            "source": "affinage",
+            "components_filled": ["CAT"],
+            "final_component_texts": {"CAT": "CAT TEXT ONE"},
+        }
+
+    def test_mid_experiment_source_switch_refused(self, tmp_path, monkeypatch):
+        path = self._setup(tmp_path, monkeypatch)
+        run_experiment(path, stage="CAT", dry_run=True)
+        with pytest.raises(ValueError, match="refusing"):
+            run_experiment(path, stage="GCR", dry_run=True, source="uniprot")
+
+    def test_source_override_beats_uses(self, tmp_path, monkeypatch):
+        path = self._setup(tmp_path, monkeypatch)
+        state = run_experiment(path, stage="CAT", dry_run=True, source="uniprot")
+        assert state["source"] == "uniprot"
+        assert state["stages"][0]["resolved"]["source"] == "uniprot"


### PR DESCRIPTION
Staged experiments: the walkup as ONE experiment, one yaml, delivered on the schema #34 reserved. A stage is an invocation, not an experiment — `run_experiment(yaml, stage="CAT")` generates that stage's conditions at runtime (`prior` = the carried build, initialised to the blank W0 floor, plus the yaml's candidates), scores them into the experiment state with the same panel shapes as a stage-less cell, and stops. Selection is deliberately a human gate (the goal metrics are too low-powered on this slate to trust an automatic rule): `select=("CAT", "process_guarded")` records the choice and carries the winning text into later stages; recording the last stage's choice assembles the final build into `carry` for the mode step.

**Reviewer's guide.** Two commits:
1. The machinery — in-place upgrade of `bench_experiment.py`. `stages:`/`uses:` go from reserved to real (`conditions:`/`stages:` mutually exclusive; `uses:` forbidden on stage-less experiments). `uses: source.carry.source` resolves the evidence source from the source experiment's state. Guards for the 2026-08-13 stale-carry incident: every invocation logs and snapshots its resolved source + carried build, a mid-experiment source switch is refused, and `--source` overrides explicitly. 12 new tests (schema, gates, carry chain, both guards).
2. `experiments/walkup.yaml` — the experiment's material: five stages (CAT→GCR→NPR→UPR→PCC) with their contract goal metrics, and the full candidate bank inlined with per-candidate rationales, including the two CAT candidates engineered from the W0 miss censuses (`process_relative`, `process_guarded`) with the census findings recorded in their rationales. Future engineered candidates are yaml edits with their rationale, visible in history.

**Validation.** Suite green at both commits (377 at tip). A dry run of the real yaml's CAT stage drives all six conditions (144 cells) through the engine: every candidate's text lands in its own condition's prompts, the source resolves through `uses:`, the state upserts one stage record, and the invocation stops at the gate — GCR does not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
