### PR TITLE
benchmark: the mode experiment

### DIFF
--- a/mozzarellm/utils/prompt_factory.py
+++ b/mozzarellm/utils/prompt_factory.py
@@ -42,21 +42,29 @@ def _resolve_screen_context(screen_context_path: Path | None, override: bool) ->
     return json.dumps(ctx_obj, ensure_ascii=False)
 
 
-def compose_stepwise_user_turns(mcp: bool) -> list[dict]:
+def compose_stepwise_user_turns(
+    mcp: bool, component_overrides: dict[str, str] | None = None
+) -> list[dict]:
     """Per-turn user content for stepwise mode.
 
     The first two canonical components (TASK + screen context) live in the system
     prompt; this returns the remaining reasoning steps formatted as `STEP N - ...`,
     plus a flag for which turns should attach MCP tools.
 
+    Args:
+        component_overrides: Optional dict mapping component keys to replacement
+            text, applied to turn components the same way system-prompt assembly
+            applies them (e.g. a LITB variant in the LIT slot).
+
     Returns a list of `{"content": str, "mcp": bool}`. The client walks these
     sequentially, prepending the cluster bundle to turn 0's content.
     """
     canonical = CANONICAL_COT_MCP_ORDER if mcp else CANONICAL_COT_ORDER
     runner_keys = canonical[2:]  # skip CAT + SC (system-prompt content)
+    overrides = component_overrides or {}
     return [
         {
-            "content": f"STEP {i + 1} - {COMPONENT_REGISTRY[key]}",
+            "content": f"STEP {i + 1} - {overrides.get(key, COMPONENT_REGISTRY[key])}",
             "mcp": (mcp and key == "LIT"),
         }
         for i, key in enumerate(runner_keys)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,12 @@ exclude = [
 [tool.ruff.lint.per-file-ignores]
 # Orchestrator puts the repo root on sys.path before importing mozzarellm.*
 "tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_orchestrator.py" = ["E402"]
+# Tests put the repo root on sys.path before importing the packages under test
+"tests/test_*.py" = ["E402"]
 # Constant-style locals / Chain-of-Thought argument naming, kept by intent
 "mozzarellm/pipeline/bundle_builder.py" = ["N806"]
 "mozzarellm/utils/prompt_factory.py" = ["N806", "N803"]
+"tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/wording_bench_alternates.py" = ["N816"]
 
 [tool.ruff.format]
 # Use double quotes for strings

--- a/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_experiment.py
+++ b/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_experiment.py
@@ -13,6 +13,12 @@ and are never overwritten. ``score_only`` re-scores the newest archived run dir
 per condition without API calls; ``dry_run`` exercises the full plumbing on
 mock outputs.
 
+A stage-less experiment may declare ``uses:`` as a mapping of input slots to
+carry paths (``source: walkup.carry.source``, ``component_overrides:
+walkup.carry.final_component_texts``) -- resolved from the named experiment's
+state at invocation, logged, and recorded in the state file, so a downstream
+experiment (mode, order) runs on exactly what the upstream one carried.
+
 STAGED experiments (the walkup) replace the static ``conditions:`` with a
 ``stages:`` block; each stage generates its conditions at runtime -- ``prior``
 (the carried build read from the experiment's own state) plus the stage's
@@ -121,10 +127,7 @@ def load_experiment(yaml_path: Path) -> dict:
             f"{yaml_path.name}: an experiment declares 'stages:' or 'conditions:', never both"
         )
     if not staged and "uses" in raw:
-        raise ValueError(
-            f"{yaml_path.name}: 'uses:' applies to staged experiments; stage-less "
-            "conditions declare their inputs (bundle_source) directly"
-        )
+        _validate_uses_mapping(yaml_path.name, raw["uses"])
     required = ("experiment", "model", "run") + (
         ("stages",) if staged else ("conditions", "selection")
     )
@@ -143,6 +146,7 @@ def load_experiment(yaml_path: Path) -> dict:
         _validate_stages(yaml_path.name, raw, route)
         return raw
 
+    uses_source = "source" in (raw.get("uses") or {})
     names = []
     for cond in raw["conditions"]:
         unknown = set(cond) - _CONDITION_KEYS
@@ -156,6 +160,12 @@ def load_experiment(yaml_path: Path) -> dict:
             raise ValueError(
                 f"{yaml_path.name}: condition {cond.get('name')!r} route "
                 f"{cond_route!r} not in registry"
+            )
+        if uses_source == ("bundle_source" in cond):
+            raise ValueError(
+                f"{yaml_path.name}: condition {cond.get('name')!r} needs its evidence "
+                "source from exactly one place -- its own bundle_source, or the "
+                "experiment's uses.source"
             )
         names.append(cond["name"])
     if len(names) != len(set(names)):
@@ -171,12 +181,35 @@ def load_experiment(yaml_path: Path) -> dict:
     return raw
 
 
+_USES_SLOTS = ("source", "component_overrides")
+
+
+def _validate_uses_mapping(yaml_name: str, uses) -> None:
+    """A stage-less experiment's uses: maps input slots to carry paths."""
+    if not isinstance(uses, dict) or not uses:
+        raise ValueError(
+            f"{yaml_name}: a stage-less experiment's 'uses:' is a mapping of input "
+            f"slot ({'/'.join(_USES_SLOTS)}) -> '<experiment>.carry.<key>'"
+        )
+    unknown = set(uses) - set(_USES_SLOTS)
+    if unknown:
+        raise ValueError(
+            f"{yaml_name}: unknown uses slot(s) {sorted(unknown)}; allowed: {list(_USES_SLOTS)}"
+        )
+    for slot, path in uses.items():
+        if not isinstance(path, str) or not _USES_RE.match(path):
+            raise ValueError(
+                f"{yaml_name}: uses.{slot} {path!r} must be '<experiment>.carry.<key>'"
+            )
+
+
 def _validate_stages(yaml_name: str, raw: dict, route: str) -> None:
     """Schema checks for a staged experiment's uses/stages blocks."""
     uses = raw.get("uses")
-    if uses is not None and not _USES_RE.match(uses):
+    if uses is not None and (not isinstance(uses, str) or not _USES_RE.match(uses)):
         raise ValueError(
-            f"{yaml_name}: uses {uses!r} must be '<experiment>.carry.<key>'"
+            f"{yaml_name}: a staged experiment's uses {uses!r} must be "
+            "'<experiment>.carry.<key>' (the evidence source)"
         )
     components = []
     for stage in raw["stages"]:
@@ -441,10 +474,11 @@ def run_experiment(
     Stage-less experiments run all conditions and apply the yaml's selection
     rule. On a staged experiment, ``stage`` runs exactly one stage and stops at
     the human gate; ``select`` records the human's choice for a stage (candidate
-    id or "prior"); ``source`` overrides the ``uses:``-resolved evidence source
-    (the stale-carry guard). Each of the three raises cleanly on the other kind
-    of experiment. score_only re-scores the newest archived run dir(s) without
-    API calls and rewrites state.
+    id or "prior"). ``source`` overrides a ``uses:``-resolved evidence source
+    (the stale-carry guard) on any experiment that declares one; stage/select
+    raise cleanly on a stage-less experiment and vice versa. score_only
+    re-scores the newest archived run dir(s) without API calls and rewrites
+    state.
     """
     exp = load_experiment(yaml_path)
     name = exp["experiment"]
@@ -464,10 +498,29 @@ def run_experiment(
             f"experiment {name!r} declares no stages; stage/select apply to "
             "staged experiments only"
         )
-    if source is not None:
+    uses = exp.get("uses") or {}
+    if source is not None and "source" not in uses:
         raise ValueError(
-            f"experiment {name!r} is stage-less; its conditions declare "
-            "bundle_source directly (source= overrides a staged 'uses:' input)"
+            f"experiment {name!r} declares no uses.source to override; its "
+            "conditions declare bundle_source directly"
+        )
+    resolved_source: str | None = None
+    resolved_overrides: dict = {}
+    if "source" in uses:
+        resolved_source = source or _resolve_uses(uses["source"])
+        if not isinstance(resolved_source, str):
+            raise ValueError(f"uses.source {uses['source']!r} resolved to a non-string")
+    if "component_overrides" in uses:
+        resolved_overrides = _resolve_uses(uses["component_overrides"])
+        if not isinstance(resolved_overrides, dict):
+            raise ValueError(
+                f"uses.component_overrides {uses['component_overrides']!r} resolved "
+                "to a non-mapping"
+            )
+    if uses:
+        print(
+            f"[{name}] resolved inputs: source={resolved_source!r}, "
+            f"carried components: {sorted(resolved_overrides) or 'none'}"
         )
 
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -475,7 +528,7 @@ def run_experiment(
     reviewer_labels = reviewer_label_sets(reviewer_csvs())
     controls = validation_specs(gt)
     run_block = exp["run"]
-    shared_overrides = run_block.get("component_overrides") or {}
+    shared_overrides = {**resolved_overrides, **(run_block.get("component_overrides") or {})}
 
     cells: dict[str, MetricPanel] = {}
     decoys, diagnostics, pathway, audit_flags, run_dirs = {}, {}, {}, {}, {}
@@ -491,7 +544,8 @@ def run_experiment(
                     f"score_only: no archived run dir {OUTPUTS / name}/{cond_name}_<stamp>/"
                 )
         else:
-            cfg = _condition_config(exp, cond_name, cond["bundle_source"], stamp, dry_run)
+            bundle_source = cond.get("bundle_source", resolved_source)
+            cfg = _condition_config(exp, cond_name, bundle_source, stamp, dry_run)
             overrides = {**shared_overrides, **(cond.get("component_overrides") or {})}
             specs = [
                 RunSpec(
@@ -505,7 +559,7 @@ def run_experiment(
                 experiment={
                     "experiment": name,
                     "condition": cond_name,
-                    "bundle_source": cond["bundle_source"],
+                    "bundle_source": bundle_source,
                     "route": route_name,
                     "component_overrides": overrides,
                 },
@@ -535,15 +589,28 @@ def run_experiment(
     )
     winner = winner_cell.split("__")[0]
 
+    # carry.source names the experiment's evidence source: the uses:-resolved
+    # input when there is one (the winner is then a condition like a mode, not
+    # a source), else the winning condition (the source experiment itself).
+    carry = {
+        key: (resolved_source if key == "source" and resolved_source else winner)
+        for key in exp.get("carry", [])
+    }
     state = {
         "experiment": name,
         "stamp": stamp if not score_only else None,
+        "uses": uses or None,
+        "resolved": (
+            {"source": resolved_source, "component_overrides": resolved_overrides}
+            if uses
+            else None
+        ),
         "runs": run_dirs,
         "winner": winner_cell,
         "winner_condition": winner,
         "dominated": dominated,
         "selection": selection,
-        "carry": dict.fromkeys(exp.get("carry", []), winner),
+        "carry": carry,
         "cells": {k: panel_json(v) for k, v in cells.items()},
         "decoys": decoys,
         "diagnostics": diagnostics,

--- a/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_orchestrator.py
+++ b/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_orchestrator.py
@@ -19,8 +19,8 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Any
 from pathlib import Path
+from typing import Any
 
 # Ensure repo root is on sys.path for imports
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -44,7 +44,6 @@ from mozzarellm.utils.prompt_factory import (
     make_single_cluster_analysis_user_prompt,
 )
 
-from .bench_routes import Route, build_routes_from_config
 from .bench_configparse import BenchmarkConfig, TimingConfig, load_config
 from .bench_dry_run import (
     _load_bundle_genes,
@@ -53,6 +52,7 @@ from .bench_dry_run import (
 )
 from .bench_metricfns import compute_all_metrics
 from .bench_reportgen import generate_report
+from .bench_routes import Route, build_routes_from_config
 from .order_bench_orderings import build_order_benchmark_routes, compose_stepwise_turns_from_route
 from .wording_bench_targets import build_wording_override_runs
 

--- a/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_orchestrator.py
+++ b/tests/phase1_prompt_benchmarking/architecture_benchmarking_workflow/bench_orchestrator.py
@@ -252,7 +252,7 @@ def construct_prompts(
         if is_order_variant and route.user_turns:
             stepwise_turns = compose_stepwise_turns_from_route(route, screen_context_path)
         else:
-            stepwise_turns = compose_stepwise_user_turns(route.mcp)
+            stepwise_turns = compose_stepwise_user_turns(route.mcp, component_overrides)
 
     return {
         "system_prompt": system_prompt,

--- a/tests/phase1_prompt_benchmarking/experiments/mode.yaml
+++ b/tests/phase1_prompt_benchmarking/experiments/mode.yaml
@@ -1,6 +1,6 @@
-# The mode experiment: delivery-mode comparison on the walkup's final build.
-# Runs single_call vs cot vs stepwise on the source and component texts the
-# walkup carried; selection is holistic (delivery format legitimately trades
+# The mode experiment: the full delivery x MCP matrix on the walkup's final
+# build -- 3 deliveries (single_call / cot / stepwise) x 3 MCP settings (none /
+# LIT / LITB). Selection is holistic (delivery format legitimately trades
 # metrics off), with the same coverage-honest primary as the source step.
 #
 # Component-mapping caveat: the walkup tunes the single_call slots
@@ -10,9 +10,17 @@
 # full tuned prompt while cot/stepwise carry only the tuned CAT lens and keep
 # canonical text for their own components -- a fair mode comparison, not a
 # verbatim prompt transplant.
+#
+# MCP settings: LIT is the canonical category-gated literature validation
+# (search NOVEL_ROLE/UNCHARACTERIZED calls); LITB is the evidence-gated
+# gap-fill (search ONLY blank-annotation genes, hard 2-call budget). LITB runs
+# as a per-condition override of the LIT slot -- the slot substitution the
+# engine supports everywhere a LIT component appears (system prompt for
+# single_call/cot, the MCP user turn for stepwise), with the text carried here
+# like every other condition text.
 
 experiment: mode
-description: delivery-mode comparison on the walkup's final assembled build
+description: delivery x MCP matrix on the walkup's final assembled build
 
 uses:
   source: walkup.carry.source
@@ -30,13 +38,51 @@ run:
   max_workers: 12
   route: single_call
 
-conditions:  # what varies is the delivery route; source + build are carried
+conditions:  # the mode matrix; source + tuned build are carried
   - name: single_call
     route: single_call
   - name: cot
     route: cot
   - name: stepwise
     route: stepwise
+  - name: single_call_lit
+    route: single_call_mcp
+  - name: cot_lit
+    route: cot_mcp
+  - name: stepwise_lit
+    route: stepwise_mcp
+  - name: single_call_litb
+    route: single_call_mcp
+    component_overrides:
+      LIT: &litb |
+          LITERATURE GAP-FILL (evidence-gated MCP):
+          Some genes in the evidence bundle have NO functional annotation provided (the annotation field is empty, or absent entirely). For those genes ONLY, use the attached PubMed MCP tools to retrieve functional evidence. Genes that already have annotation text MUST NOT be looked up, regardless of how you classify them.
+
+          BEFORE ANY TOOL USE — count the GAP set: genes whose functional-annotation field is empty or absent. This count fixes your ENTIRE tool budget:
+          - GAP set EMPTY (zero blank genes) → make ZERO tool calls. Do not search anything at all. Go straight to classification. Most clusters land here.
+          - GAP set NON-EMPTY → make EXACTLY TWO tool calls, no more: (1) ONE `search_articles` with all gap genes OR'd together `(GAP1[tiab] OR GAP2[tiab] OR ...)`, max_results=30, [tiab] on every symbol; (2) ONE `get_article_metadata` on the returned PMIDs. Then STOP calling tools permanently.
+
+          ABSOLUTE tool rules (violating any of these breaks the run):
+          - The 2-call cap is HARD. Never exceed it under any circumstance.
+          - Issue the search EXACTLY ONCE. NEVER repeat, re-word, refine, or re-run a search — not even if it returns few results, zero results, or nothing useful. If the search returns nothing for a gene, record "no literature found" for that gene and move on. Re-searching for any reason is FORBIDDEN.
+          - NEVER search a gene that already has annotation text — only the blank/GAP genes.
+          - Do NOT search per-gene, and do NOT use the tools to explore or brainstorm pathways.
+
+          For each GAP gene, extract a one-line functional summary from the retrieved literature, or record "no literature found".
+
+          Classify GAP genes on equal footing with the pre-annotated genes using the retrieved evidence: a GAP gene with direct pathway literature → ESTABLISHED/NOVEL_ROLE as warranted; a GAP gene with no retrievable literature → UNCHARACTERIZED (DARK_GENE).
+
+          In the final output, add a top-level `mcp_gapfill` array — one entry per GAP gene: {"gene": "...", "evidence_found": true|false, "driving_pmids": ["..."], "retrieved_summary": "..."}. Empty array if there were no GAP genes.
+
+          CRITICAL OUTPUT CONSTRAINT: Your entire response MUST be a single valid JSON object and nothing else. Start with `{` and end with `}`. Do NOT write any preamble, plan, or commentary about your searches — no "Based on my analysis...", no "According to PubMed...", no restating of the query. Do NOT write any text before the opening brace or after the closing brace. Report every literature finding ONLY inside JSON fields (rationale, mcp_gapfill), never as prose.
+  - name: cot_litb
+    route: cot_mcp
+    component_overrides:
+      LIT: *litb
+  - name: stepwise_litb
+    route: stepwise_mcp
+    component_overrides:
+      LIT: *litb
 
 selection:
   primary: coverage_weighted_category

--- a/tests/phase1_prompt_benchmarking/experiments/mode.yaml
+++ b/tests/phase1_prompt_benchmarking/experiments/mode.yaml
@@ -1,0 +1,45 @@
+# The mode experiment: delivery-mode comparison on the walkup's final build.
+# Runs single_call vs cot vs stepwise on the source and component texts the
+# walkup carried; selection is holistic (delivery format legitimately trades
+# metrics off), with the same coverage-honest primary as the source step.
+#
+# Component-mapping caveat: the walkup tunes the single_call slots
+# (CAT/GCR/NPR/UPR/PCC); cot and stepwise assemble from their own slots
+# (cPH/cGCR/cPri/cPSC/cVer/cO), sharing only CAT and SC. Carried overrides for
+# slots a route doesn't have are inert at assembly, so single_call runs the
+# full tuned prompt while cot/stepwise carry only the tuned CAT lens and keep
+# canonical text for their own components -- a fair mode comparison, not a
+# verbatim prompt transplant.
+
+experiment: mode
+description: delivery-mode comparison on the walkup's final assembled build
+
+uses:
+  source: walkup.carry.source
+  component_overrides: walkup.carry.final_component_texts
+
+model:
+  provider: anthropic
+  model_name: claude-sonnet-5
+  # temperature omitted: claude-sonnet-5 rejects non-default sampling params
+  max_tokens: 16000
+  thinking: false
+
+run:
+  replicates: 3
+  max_workers: 12
+  route: single_call
+
+conditions:  # what varies is the delivery route; source + build are carried
+  - name: single_call
+    route: single_call
+  - name: cot
+    route: cot
+  - name: stepwise
+    route: stepwise
+
+selection:
+  primary: coverage_weighted_category
+  metrics: [category, novel_subclass, unchar_subclass, coherence, coverage]
+
+carry: [source, mode]  # carry.source = the resolved source; carry.mode = winner

--- a/tests/test_bench_configparse.py
+++ b/tests/test_bench_configparse.py
@@ -13,15 +13,10 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_configparse import (
-    ArchitectureBenchmarkConfig,
-    BenchmarkConfig,
     ClusterFilter,
     ModelConfig,
-    OrderBenchmarkConfig,
-    PathsConfig,
     RunConfig,
     TimingConfig,
-    WordingBenchmarkConfig,
     load_config,
 )
 

--- a/tests/test_bench_dry_run.py
+++ b/tests/test_bench_dry_run.py
@@ -7,8 +7,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))

--- a/tests/test_bench_experiment.py
+++ b/tests/test_bench_experiment.py
@@ -64,10 +64,6 @@ class TestLoadExperiment:
         assert exp["run"]["route"] == "single_call"
         assert exp["carry"] == ["source"]
 
-    def test_uses_rejected_on_stageless_experiment(self, tmp_path):
-        with pytest.raises(ValueError, match="'uses:' applies to staged experiments"):
-            load_experiment(_write_yaml(tmp_path, _MINIMAL_YAML + "uses: source.carry.source\n"))
-
     def test_missing_required_key_rejected(self, tmp_path):
         text = _MINIMAL_YAML.replace(
             "selection: {primary: coverage_weighted_category, metrics: [category, coverage]}\n", ""
@@ -291,8 +287,8 @@ class TestStagedSchema:
         with pytest.raises(ValueError, match="is staged"):
             run_experiment(_write_yaml(tmp_path, _STAGED_YAML))
 
-    def test_source_override_rejected_on_stageless(self, tmp_path):
-        with pytest.raises(ValueError, match="is stage-less"):
+    def test_source_override_needs_a_uses_source(self, tmp_path):
+        with pytest.raises(ValueError, match="declares no uses.source"):
             run_experiment(_write_yaml(tmp_path, _MINIMAL_YAML), source="affinage")
 
 
@@ -390,3 +386,96 @@ def test_walkup_yaml_parses_with_the_full_candidate_bank():
     for stage in stages.values():
         for cand in stage["candidates"]:
             assert cand["rationale"] and cand["text"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-experiment inputs on stage-less experiments (uses: mapping)
+# ---------------------------------------------------------------------------
+
+_DOWNSTREAM_YAML = """\
+experiment: m
+model: {model_name: claude-sonnet-5}
+run: {replicates: 1, route: single_call}
+uses:
+  source: walkup.carry.source
+  component_overrides: walkup.carry.final_component_texts
+conditions:
+  - {name: single_call, route: single_call}
+  - {name: cot, route: cot}
+selection: {primary: coverage_weighted_category, metrics: [category, coverage]}
+carry: [source, mode]
+"""
+
+
+class TestStagelessUses:
+    def _setup(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(bench_experiment, "OUTPUTS", tmp_path)
+        monkeypatch.setattr(bench_experiment, "GT_PATH", tmp_path / "consensus_gt.csv")
+        (tmp_path / "walkup").mkdir()
+        (tmp_path / "walkup" / "walkup_state.json").write_text(
+            json.dumps(
+                {
+                    "carry": {
+                        "source": "affinage",
+                        "final_component_texts": {"CAT": "TUNED CAT TEXT"},
+                    }
+                }
+            )
+        )
+        return _write_yaml(tmp_path, _DOWNSTREAM_YAML)
+
+    def test_uses_mapping_parses(self, tmp_path):
+        exp = load_experiment(_write_yaml(tmp_path, _DOWNSTREAM_YAML))
+        assert exp["uses"]["source"] == "walkup.carry.source"
+
+    def test_string_uses_rejected_on_stageless(self, tmp_path):
+        text = _DOWNSTREAM_YAML.replace(
+            "uses:\n  source: walkup.carry.source\n"
+            "  component_overrides: walkup.carry.final_component_texts\n",
+            "uses: walkup.carry.source\n",
+        )
+        with pytest.raises(ValueError, match="is a mapping"):
+            load_experiment(_write_yaml(tmp_path, text))
+
+    def test_unknown_uses_slot_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="unknown uses slot"):
+            load_experiment(
+                _write_yaml(tmp_path, _DOWNSTREAM_YAML.replace("source:", "src:", 1))
+            )
+
+    def test_bundle_source_conflicts_with_uses_source(self, tmp_path):
+        text = _DOWNSTREAM_YAML.replace(
+            "{name: cot, route: cot}", "{name: cot, route: cot, bundle_source: uniprot}"
+        )
+        with pytest.raises(ValueError, match="exactly one place"):
+            load_experiment(_write_yaml(tmp_path, text))
+
+    def test_condition_without_any_source_rejected(self, tmp_path):
+        text = _MINIMAL_YAML.replace("{name: b, bundle_source: affinage}", "{name: b}")
+        with pytest.raises(ValueError, match="exactly one place"):
+            load_experiment(_write_yaml(tmp_path, text))
+
+    def test_resolved_inputs_reach_every_condition(self, tmp_path, monkeypatch):
+        path = self._setup(tmp_path, monkeypatch)
+        state = run_experiment(path, dry_run=True)
+
+        assert state["resolved"]["source"] == "affinage"
+        assert state["resolved"]["component_overrides"] == {"CAT": "TUNED CAT TEXT"}
+        # carry.source is the resolved input, not the winning condition.
+        assert state["carry"]["source"] == "affinage"
+        assert state["carry"]["mode"] == state["winner_condition"]
+        # The carried CAT text reaches both routes' prompts (CAT is a shared slot).
+        for d in state["runs"].values():
+            prompts = (tmp_path / "m" / d / "prompts.jsonl").read_text()
+            assert "TUNED CAT TEXT" in prompts
+        # Both arms ran on the resolved source's evidence view.
+        snap = json.loads(
+            (tmp_path / "m" / state["runs"]["cot"] / "config_snapshot.yaml").read_text()
+        )
+        assert snap["experiment"]["bundle_source"] == "affinage"
+
+    def test_source_kwarg_overrides_uses_resolution(self, tmp_path, monkeypatch):
+        path = self._setup(tmp_path, monkeypatch)
+        state = run_experiment(path, dry_run=True, source="uniprot")
+        assert state["resolved"]["source"] == "uniprot"
+        assert state["carry"]["source"] == "uniprot"

--- a/tests/test_bench_experiment.py
+++ b/tests/test_bench_experiment.py
@@ -484,12 +484,28 @@ class TestStagelessUses:
 MODE_YAML = SOURCE_YAML.parent / "mode.yaml"
 
 
-def test_mode_yaml_parses_and_carries_the_walkup_build():
+def test_mode_yaml_parses_as_the_full_delivery_x_mcp_matrix():
     exp = load_experiment(MODE_YAML)
     assert exp["uses"] == {
         "source": "walkup.carry.source",
         "component_overrides": "walkup.carry.final_component_texts",
     }
-    assert [c["name"] for c in exp["conditions"]] == ["single_call", "cot", "stepwise"]
-    assert [c["route"] for c in exp["conditions"]] == ["single_call", "cot", "stepwise"]
+    conds = {c["name"]: c for c in exp["conditions"]}
+    assert list(conds) == [
+        "single_call", "cot", "stepwise",
+        "single_call_lit", "cot_lit", "stepwise_lit",
+        "single_call_litb", "cot_litb", "stepwise_litb",
+    ]
+    for delivery in ("single_call", "cot", "stepwise"):
+        assert conds[delivery]["route"] == delivery
+        assert conds[f"{delivery}_lit"]["route"] == f"{delivery}_mcp"
+        litb = conds[f"{delivery}_litb"]
+        assert litb["route"] == f"{delivery}_mcp"
+        assert litb["component_overrides"]["LIT"].startswith("LITERATURE GAP-FILL")
+    # One LITB text, anchored -- identical across the three deliveries.
+    texts = {
+        conds[f"{d}_litb"]["component_overrides"]["LIT"]
+        for d in ("single_call", "cot", "stepwise")
+    }
+    assert len(texts) == 1
     assert exp["carry"] == ["source", "mode"]

--- a/tests/test_bench_experiment.py
+++ b/tests/test_bench_experiment.py
@@ -479,3 +479,17 @@ class TestStagelessUses:
         state = run_experiment(path, dry_run=True, source="uniprot")
         assert state["resolved"]["source"] == "uniprot"
         assert state["carry"]["source"] == "uniprot"
+
+
+MODE_YAML = SOURCE_YAML.parent / "mode.yaml"
+
+
+def test_mode_yaml_parses_and_carries_the_walkup_build():
+    exp = load_experiment(MODE_YAML)
+    assert exp["uses"] == {
+        "source": "walkup.carry.source",
+        "component_overrides": "walkup.carry.final_component_texts",
+    }
+    assert [c["name"] for c in exp["conditions"]] == ["single_call", "cot", "stepwise"]
+    assert [c["route"] for c in exp["conditions"]] == ["single_call", "cot", "stepwise"]
+    assert exp["carry"] == ["source", "mode"]

--- a/tests/test_bench_metricfns.py
+++ b/tests/test_bench_metricfns.py
@@ -25,9 +25,6 @@ for _name, _subdir in [
         sys.modules[_name] = _m
 
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_metricfns import (
-    VALID_CONFIDENCE_VALUES,
-    VALID_NOVEL_SUBCLASSES,
-    VALID_UNCHARACTERIZED_SUBCLASSES,
     compute_all_metrics,
     compute_efficiency_metrics,
     compute_logical_metrics,

--- a/tests/test_bench_orchestrator_unit.py
+++ b/tests/test_bench_orchestrator_unit.py
@@ -627,3 +627,30 @@ class TestEvidenceSourceThreading:
         user_prompt = self._run_with_source(tmp_path, "both")
         assert "UniProt_functional_annotation" in user_prompt
         assert "affinage_functional_annotation" in user_prompt
+
+
+class TestStepwiseTurnOverrides:
+    def test_component_override_reaches_the_stepwise_turn(self, tmp_path):
+        """A LIT-slot override lands in the stepwise MCP turn, not just the system prompt."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        bundle_path, ctx_path = _setup_bundle_and_context(tmp_path)
+        config = _make_dry_run_config(output_dir)
+        record = execute_single_run(
+            route=ROUTE_REGISTRY["stepwise_mcp"],
+            screen_name="denali",
+            cluster_id="21",
+            bundle_path=bundle_path,
+            screen_context_path=ctx_path,
+            replicate=1,
+            config=config,
+            client=None,
+            output_dir=output_dir,
+            component_overrides={"LIT": "LITB OVERRIDE TEXT"},
+        )
+        prompts = json.loads((output_dir / "prompts.jsonl").read_text().splitlines()[0])
+        turns = prompts["stepwise_turns"]
+        lit_turns = [t for t in turns if t["mcp"]]
+        assert len(lit_turns) == 1
+        assert "LITB OVERRIDE TEXT" in lit_turns[0]["content"]
+        assert record["error"] is None

--- a/tests/test_bench_orchestrator_unit.py
+++ b/tests/test_bench_orchestrator_unit.py
@@ -15,16 +15,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 try:
     import pandas as pd
-    from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_orchestrator import (
-        _build_run_id,
-        _build_timing_dict,
-        _client_from_config,
-        _filter_clusters,
-        _resolve_bundle_path,
-        _resolve_screen_context_path,
-        _run_benchmark_loop,
-        execute_single_run,
-    )
+
     from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow import (
         bench_orchestrator,
     )
@@ -36,9 +27,18 @@ try:
         RunConfig,
         TimingConfig,
     )
+    from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_orchestrator import (
+        _build_run_id,
+        _build_timing_dict,
+        _client_from_config,
+        _filter_clusters,
+        _resolve_bundle_path,
+        _resolve_screen_context_path,
+        _run_benchmark_loop,
+        execute_single_run,
+    )
     from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_routes import (
         ROUTE_REGISTRY,
-        Route,
     )
 
     _IMPORTS_OK = True

--- a/tests/test_bench_reportgen.py
+++ b/tests/test_bench_reportgen.py
@@ -4,7 +4,6 @@ No API calls; uses tmp_path and synthetic data only.
 """
 
 import csv
-import json
 import sys
 from pathlib import Path
 
@@ -15,12 +14,9 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_reportgen import (
-    _build_report_markdown,
     _summarize_route,
-    _write_aggregate_csv,
     generate_report,
 )
-
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_bench_trace_parser.py
+++ b/tests/test_bench_trace_parser.py
@@ -8,21 +8,17 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_trace_parser import (
     CSV_COLUMNS,
-    TRACE_FILENAME_RE,
     _extract_gene_rows,
     extract_predictions_from_traces,
     parse_trace_filename,
     write_prediction_csvs,
 )
-
 
 # ---- helpers ---------------------------------------------------------------
 

--- a/tests/test_order_bench_orderings.py
+++ b/tests/test_order_bench_orderings.py
@@ -10,23 +10,22 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from mozzarellm.prompt_components import COMPONENT_REGISTRY
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_routes import (
+    ROUTE_REGISTRY,
     Route,
     StepwiseTurn,
     build_routes_from_config,
-    ROUTE_REGISTRY,
 )
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.order_bench_orderings import (
-    ORDER_VARIANTS,
     _ORDER_SPECS,
+    ORDER_VARIANTS,
     OrderVariant,
     apply_order_variant,
     build_order_benchmark_routes,
     resolve_order_variant_ids,
     validate_order_variant_names,
 )
-from mozzarellm.prompt_components import COMPONENT_REGISTRY
-
 
 # ============================================================================
 # Variant registry tests
@@ -39,7 +38,7 @@ class TestOrderVariantsRegistry:
         assert set(ORDER_VARIANTS.keys()) == expected
 
     def test_all_variants_have_required_fields(self):
-        for key, variant in ORDER_VARIANTS.items():
+        for variant in ORDER_VARIANTS.values():
             assert isinstance(variant, OrderVariant)
             assert isinstance(variant.name, str) and len(variant.name) > 0
             assert isinstance(variant.description, str) and len(variant.description) > 0

--- a/tests/test_order_bench_prompt_construction.py
+++ b/tests/test_order_bench_prompt_construction.py
@@ -230,7 +230,8 @@ class TestPhase2ComponentOrder:
                 output_dir=tmp_path,
             )
 
-            mock_canonical_turns.assert_called_once_with(route.mcp)
+            # Canonical turns, with the caller's component overrides forwarded.
+            mock_canonical_turns.assert_called_once_with(route.mcp, None)
             mock_order_turns.assert_not_called()
 
 

--- a/tests/test_order_bench_prompt_construction.py
+++ b/tests/test_order_bench_prompt_construction.py
@@ -7,7 +7,7 @@ build user turns from the route's user_turns field.
 
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -15,19 +15,15 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_orchestrator import (
+    construct_prompts,
+)
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_routes import (
-    Route,
-    StepwiseTurn,
     ROUTE_REGISTRY,
 )
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.order_bench_orderings import (
     apply_order_variant,
 )
-from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_orchestrator import (
-    construct_prompts,
-)
-from mozzarellm.prompt_components import COMPONENT_REGISTRY
-
 
 # ============================================================================
 # Fixtures

--- a/tests/test_wording_bench.py
+++ b/tests/test_wording_bench.py
@@ -21,23 +21,18 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.bench_routes import (
-    ROUTE_REGISTRY,
-)
+from mozzarellm.prompt_components import COMPONENT_REGISTRY
+from mozzarellm.utils.prompt_factory import make_cluster_analysis_system_prompt
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.wording_bench_alternates import (
     WORDING_ALTERNATE_SET_REGISTRY,
 )
 from tests.phase1_prompt_benchmarking.architecture_benchmarking_workflow.wording_bench_targets import (
     WORDING_OVERRIDE_TARGET_REGISTRY,
-    WordingOverrideRun,
     WordingOverrideTarget,
     build_wording_override_runs,
     resolve_source,
     resolve_target_ids,
 )
-from mozzarellm.prompt_components import COMPONENT_REGISTRY
-from mozzarellm.utils.prompt_factory import make_cluster_analysis_system_prompt
-
 
 # ============================================================================
 # Alternate source registry


### PR DESCRIPTION
The mode experiment: the full delivery x MCP matrix -- 3 deliveries (single_call / cot / stepwise) x 3 MCP settings (none / LIT / LITB) -- on the walkup's final assembled build, as one yaml.

**Reviewer's guide.** Five commits:
1. Cross-experiment inputs for stage-less experiments — `uses:` as a mapping of input slots to carry paths (`source: walkup.carry.source` feeds every condition's bundle_source; `component_overrides: walkup.carry.final_component_texts` injects the carried build). Inputs resolve at invocation, are logged and recorded in state, `carry.source` becomes the resolved source, and `source=` overrides explicitly — the same stale-carry guards the staged path has. A condition's source must come from exactly one place (own `bundle_source` XOR `uses.source`). 7 new tests.
2. `experiments/mode.yaml`. Component-mapping caveat, documented in the yaml: the walkup tunes single_call slots; cot/stepwise share only CAT/SC (overrides for absent slots are inert at assembly), so single_call runs the full tuned prompt while cot/stepwise carry the tuned CAT lens with canonical text for their own components — a fair mode comparison, not a verbatim transplant.

3. Ruff-clean the repo — zero findings from `ruff check .`; auto-fixes plus two intent-based per-file ignores (tests' sys.path-before-import pattern for E402; the wording alternates' component-cased constants for N816, dropped again when that file retires downstack).
4. `core:` thread component overrides into stepwise turns — stepwise delivers reasoning components as user turns, and turn content came straight from the component registry, so a turn-component override was silently ignored; `compose_stepwise_user_turns` now applies overrides the same way system-prompt assembly does (test asserts the override lands in the MCP turn).
5. The full mode matrix: nine conditions. LIT arms use the registry's `*_mcp` routes (category-gated literature validation); LITB arms substitute the evidence-gated gap-fill text into the LIT slot via a per-condition override — one anchored text in the yaml, applied wherever the LIT component appears (system prompt for single_call/cot, the MCP user turn for stepwise).

**Validation.** Suite green at both commits (388/389); the resolution test drives a dry run end-to-end and asserts the carried text reaches both routes' prompts and the resolved source lands in every condition's config snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)