### PR TITLE
core: stream large-output Anthropic requests

### DIFF
--- a/mozzarellm/clients/llm_api_clients.py
+++ b/mozzarellm/clients/llm_api_clients.py
@@ -472,9 +472,24 @@ class AnthropicClient(LLMClientBase):
         self._resolve_params()
         return dict(self._resolved_thinking_kwarg)
 
+    # Above this output size the SDK refuses non-streaming requests ("Streaming
+    # is required for operations that may take longer than 10 minutes"), so we
+    # stream and accumulate. 16k -- the benchmark-validated ceiling -- stays on
+    # the plain path.
+    _STREAM_MIN_OUTPUT_TOKENS = 16_001
+
     def _create_message(self, client, base: dict):
-        """messages.create with the resolved sampling and thinking params."""
-        return client.messages.create(**base, **self._sampling_kwargs(), **self._thinking_kwarg())
+        """messages.create with the resolved sampling and thinking params.
+
+        Large-output requests go through messages.stream + get_final_message(),
+        which returns the same Message object the non-streaming call would.
+        https://github.com/anthropics/anthropic-sdk-python#long-requests
+        """
+        kwargs = {**base, **self._sampling_kwargs(), **self._thinking_kwarg()}
+        if kwargs.get("max_tokens", 0) >= self._STREAM_MIN_OUTPUT_TOKENS:
+            with client.messages.stream(**kwargs) as stream:
+                return stream.get_final_message()
+        return client.messages.create(**kwargs)
 
     def _make_api_call(self, system_prompt: str, user_prompt: str) -> str:
         """

--- a/tests/test_llm_api_clients.py
+++ b/tests/test_llm_api_clients.py
@@ -126,3 +126,64 @@ def test_enabled_thinking_budget_stays_within_max_tokens():
     assert 1024 <= budget < 1500
     assert c.resolved_params["thinking"] == "enabled"
 
+
+
+# ---------------------------------------------------------------------------
+# _create_message: streaming for large outputs
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    def __init__(self, message):
+        self._message = message
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get_final_message(self):
+        return self._message
+
+
+class _FakeMessages:
+    def __init__(self):
+        self.created_with = None
+        self.streamed_with = None
+
+    def create(self, **kwargs):
+        self.created_with = kwargs
+        return "created"
+
+    def stream(self, **kwargs):
+        self.streamed_with = kwargs
+        return _FakeStream("streamed")
+
+
+class _FakeAnthropic:
+    def __init__(self):
+        self.messages = _FakeMessages()
+
+
+def _anthropic_client(max_tokens):
+    from mozzarellm.clients.llm_api_clients import AnthropicClient
+
+    return AnthropicClient(
+        "claude-sonnet-5", 0.2, max_tokens, None, None, None, "test-key", False
+    )
+
+
+def test_benchmark_ceiling_stays_non_streaming():
+    client = _anthropic_client(16000)
+    fake = _FakeAnthropic()
+    assert client._create_message(fake, {"max_tokens": 16000}) == "created"
+    assert fake.messages.streamed_with is None
+
+
+def test_large_outputs_stream_and_return_the_final_message():
+    client = _anthropic_client(32000)
+    fake = _FakeAnthropic()
+    assert client._create_message(fake, {"max_tokens": 32000}) == "streamed"
+    assert fake.messages.created_with is None
+    assert fake.messages.streamed_with["max_tokens"] == 32000


### PR DESCRIPTION
Above the benchmark-validated 16k output ceiling, `_create_message` routes through `messages.stream` + `get_final_message()` (same Message object out; the SDK's long-request guard refuses non-streaming there — hit live during notebook validation at 32k). 16k and below stay on the plain path, so benchmark runs are byte-for-byte unchanged. Unit tests cover both sides of the threshold. Prerequisite for the walkup's feature stage and full-coverage feature-mode notebook runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZM4Pv2WDXKpuVcw9pdwrr