### PR TITLE
core: provider-generic analyze (OpenAI, Gemini)

### DIFF
--- a/benchmarks/workflow/bench_orchestrator.py
+++ b/benchmarks/workflow/bench_orchestrator.py
@@ -391,11 +391,13 @@ def execute_single_run(
         raw_outputs = generate_mock_raw_outputs(route)
     else:
         try:
+            stepwise_turns = prompts["stepwise_turns"]
             parsed, raw_outputs = client.analyze(
                 system_prompt=system_prompt,
                 user_prompt=user_prompt,
                 mode=route.mode,
                 mcp=route.mcp,
+                **({"stepwise_turns": stepwise_turns} if stepwise_turns is not None else {}),
             )
             error = raw_outputs.get("error")
         except Exception as e:

--- a/mozzarellm/clients/llm_api_clients.py
+++ b/mozzarellm/clients/llm_api_clients.py
@@ -200,6 +200,77 @@ class LLMClientBase(ABC):
         """Make the actual API call to the provider."""
         pass
 
+    def analyze(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str | None = None,
+        mode: str = "cot",
+        mcp: bool = False,
+        batch: bool = False,
+        max_retries: int = 3,
+        **_anthropic_only,
+    ) -> tuple[dict | None, dict]:
+        """Provider-generic single-call analysis -- (parsed, raw_outputs).
+
+        Covers the standard/cot single-call path for any provider via
+        _make_api_call; MCP, stepwise, and batch are Anthropic features and the
+        AnthropicClient override handles them. raw_outputs has the uniform
+        shape consumed by mozzarellm.utils.trace.save_trace().
+        """
+        from mozzarellm.utils.llm_analysis_utils import process_cluster_response
+        from mozzarellm.utils.pricing import compute_cost
+
+        if mode not in ("standard", "cot"):
+            raise ValueError(
+                f"mode {mode!r} is not supported on {type(self).__name__}; "
+                "use 'standard' or 'cot' (stepwise is Anthropic-only)"
+            )
+        if mcp or batch:
+            raise ValueError(
+                "PubMed MCP validation and batch analysis are Anthropic-only; "
+                f"{type(self).__name__} supports single-call standard/cot"
+            )
+        if user_prompt is None:
+            raise ValueError("user_prompt is required")
+
+        self._last_usage = None
+        error: str | None = None
+        text = ""
+        start = time.time()
+        for attempt in range(max_retries):
+            try:
+                text = self._make_api_call(system_prompt, user_prompt)
+                error = None
+                break
+            except Exception as e:
+                error = f"{type(e).__name__}: {e}"
+                if attempt < max_retries - 1:
+                    time.sleep(min(5 * 2**attempt, 30))
+        elapsed = time.time() - start
+
+        usage = self._last_usage or {}
+        input_tokens = usage.get("input_tokens")
+        output_tokens = usage.get("output_tokens")
+        cost_usd, pricing_warning = (None, None)
+        if input_tokens is not None and output_tokens is not None:
+            cost_usd, pricing_warning = compute_cost(self.model, input_tokens, output_tokens)
+
+        parsed = process_cluster_response(text) if text and error is None else None
+        raw_outputs = {
+            "response_text": text,
+            "tool_calls": [],
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "elapsed_s": round(elapsed, 2),
+            "cost_usd": cost_usd,
+            "pricing_warning": pricing_warning,
+            "schema_warnings": [],
+            "error": error,
+            "steps": [],
+        }
+        return parsed, raw_outputs
+
     @abstractmethod
     def _make_batch_api_call(self, system_prompt: str, user_prompt: str) -> str:
         """Make a batched API call to the provider."""
@@ -305,6 +376,10 @@ class OpenAIClient(LLMClientBase):
         if hasattr(response, "usage"):
             tokens = response.usage.total_tokens
             logger.info(f"OpenAI tokens used: {tokens}")
+            self._last_usage = {
+                "input_tokens": response.usage.prompt_tokens,
+                "output_tokens": response.usage.completion_tokens,
+            }
 
         return response.choices[0].message.content
 
@@ -1127,6 +1202,12 @@ class GeminiClient(LLMClientBase):
             model=self.model, contents=user_prompt, config=config
         )
 
+        meta = getattr(response, "usage_metadata", None)
+        if meta is not None:
+            self._last_usage = {
+                "input_tokens": meta.prompt_token_count,
+                "output_tokens": meta.candidates_token_count,
+            }
         return response.text
 
     def _make_batch_api_call(

--- a/mozzarellm/clients/llm_api_clients.py
+++ b/mozzarellm/clients/llm_api_clients.py
@@ -599,6 +599,7 @@ class AnthropicClient(LLMClientBase):
         max_retries: int = 3,
         include_features: bool = False,
         source: str = "both",
+        stepwise_turns: list[dict] | None = None,
     ) -> tuple[dict | None, dict]:
         """Single entry point for cluster analysis.
 
@@ -624,6 +625,8 @@ class AnthropicClient(LLMClientBase):
         """
         if mode not in ("standard", "cot", "stepwise"):
             raise ValueError(f"mode must be one of 'standard', 'cot', 'stepwise'; got {mode!r}")
+        if stepwise_turns is not None and mode != "stepwise":
+            raise ValueError("stepwise_turns is only valid with mode='stepwise'")
         if batch and (mcp or mode == "stepwise"):
             raise ValueError(
                 "batch=True is incompatible with mcp=True or mode='stepwise' "
@@ -651,6 +654,7 @@ class AnthropicClient(LLMClientBase):
                 user_prompt=user_prompt,
                 mcp=mcp,
                 max_retries=max_retries,
+                turns=stepwise_turns,
             )
 
         if mcp:
@@ -777,6 +781,7 @@ class AnthropicClient(LLMClientBase):
             self.model, response.usage.input_tokens, response.usage.output_tokens
         )
 
+        stop_reason = getattr(response, "stop_reason", None)
         raw_outputs = self._empty_raw_outputs()
         raw_outputs.update(
             {
@@ -787,6 +792,7 @@ class AnthropicClient(LLMClientBase):
                 "elapsed_s": elapsed,
                 "cost_usd": cost,
                 "pricing_warning": pricing_warning,
+                "stop_reason": stop_reason,
             }
         )
 
@@ -798,13 +804,20 @@ class AnthropicClient(LLMClientBase):
             "cost_usd": cost,
             "time_seconds": round(elapsed, 1),
             "tool_calls": len(tool_calls),
+            "stop_reason": stop_reason,
         }
         if pricing_warning:
             meta["pricing_warning"] = pricing_warning
 
         if not parsed:
-            meta_err = {**meta, "error": "failed to parse JSON", "raw_output": output_text[:1000]}
-            raw_outputs["error"] = "failed to parse JSON"
+            # A max_tokens stop with no (or partial) text is a truncation, not a
+            # parsing defect -- label it so failure accounting can tell them apart.
+            if stop_reason == "max_tokens":
+                error = "output truncated at max_tokens" + (" (no text)" if not output_text else "")
+            else:
+                error = "failed to parse JSON"
+            meta_err = {**meta, "error": error, "raw_output": output_text[:1000]}
+            raw_outputs["error"] = error
             return ({"_validation_metadata": meta_err}, raw_outputs)
 
         schema_warnings = _validate_literature_blocks(parsed)
@@ -857,12 +870,17 @@ class AnthropicClient(LLMClientBase):
         mcp: bool,
         max_retries: int,
         max_tokens: int = 16000,
+        turns: list[dict] | None = None,
     ) -> tuple[dict | None, dict]:
         """Run the canonical CoT chain as N sequential, multi-turn API calls.
 
         Each step is a separate API call; prior assistant responses are appended
         to `messages` so step N sees steps 1..N-1's outputs. Steps in the MCP
         index set get PubMed tools attached; others use the plain endpoint.
+
+        turns: prebuilt per-turn content ({"content", "mcp"} dicts, e.g. from
+        compose_stepwise_user_turns with component overrides applied); when
+        None, the canonical turn list is composed here.
 
         On any step failure, iteration aborts and a partial trace is returned
         with steps 1..N-1 preserved.
@@ -877,7 +895,8 @@ class AnthropicClient(LLMClientBase):
         from mozzarellm.utils.trace import extract_mcp_tool_calls
 
         # Per-turn user content + MCP routing decided by prompt_factory.
-        turns = compose_stepwise_user_turns(mcp)
+        if turns is None:
+            turns = compose_stepwise_user_turns(mcp)
 
         messages: list[dict] = []
         step_records: list[dict] = []
@@ -946,6 +965,7 @@ class AnthropicClient(LLMClientBase):
                     "output_tokens": out_tok,
                     "elapsed_s": round(elapsed, 2),
                     "cost_usd": cost,
+                    "stop_reason": getattr(response, "stop_reason", None),
                     "error": None,
                 }
             )
@@ -989,8 +1009,13 @@ class AnthropicClient(LLMClientBase):
             meta["pricing_warning"] = "; ".join(pricing_warnings)
 
         if not parsed:
-            meta_err = {**meta, "error": "failed to parse JSON", "raw_output": final_text[:1000]}
-            raw_outputs["error"] = "failed to parse JSON"
+            final_stop = step_records[-1].get("stop_reason") if step_records else None
+            if final_stop == "max_tokens":
+                error = "output truncated at max_tokens" + (" (no text)" if not final_text else "")
+            else:
+                error = "failed to parse JSON"
+            meta_err = {**meta, "error": error, "raw_output": final_text[:1000]}
+            raw_outputs["error"] = error
             return ({"_validation_metadata": meta_err}, raw_outputs)
 
         if mcp:

--- a/mozzarellm/pipeline/screen_analysis.py
+++ b/mozzarellm/pipeline/screen_analysis.py
@@ -22,6 +22,7 @@ from mozzarellm.utils.cluster_utils import build_cluster_id_to_bundle_path
 from mozzarellm.utils.io import load_table
 from mozzarellm.utils.llm_analysis_utils import save_cluster_analysis
 from mozzarellm.utils.prompt_factory import (
+    compose_stepwise_user_turns,
     make_cluster_analysis_system_prompt,
     make_single_cluster_analysis_user_prompt,
 )
@@ -166,6 +167,9 @@ def analyze_screen(
         component_order=(list(CANONICAL_FEATURE_INTERP_COT_ORDER) if include_features else None),
         component_overrides=component_overrides,
     )
+    stepwise_turns = (
+        compose_stepwise_user_turns(mcp, component_overrides) if mode == "stepwise" else None
+    )
 
     results: dict = {}
     errors: dict = {}
@@ -184,6 +188,7 @@ def analyze_screen(
                 user_prompt=user_prompt,
                 mode=mode,
                 mcp=mcp,
+                **({"stepwise_turns": stepwise_turns} if stepwise_turns is not None else {}),
             )
         except Exception as e:  # noqa: BLE001 -- one bad cluster must not kill the run
             errors[cluster_id] = str(e)

--- a/mozzarellm/utils/pricing.py
+++ b/mozzarellm/utils/pricing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 # (input_$_per_M_tokens, output_$_per_M_tokens)
 MODEL_PRICING: dict[str, tuple[float, float]] = {
+    "claude-sonnet-5": (3.0, 15.0),
     "claude-opus-4-7": (15.0, 75.0),
     "claude-opus-4-5": (15.0, 75.0),
     "claude-sonnet-4-6": (3.0, 15.0),

--- a/tests/test_llm_api_clients.py
+++ b/tests/test_llm_api_clients.py
@@ -187,3 +187,52 @@ def test_large_outputs_stream_and_return_the_final_message():
     assert client._create_message(fake, {"max_tokens": 32000}) == "streamed"
     assert fake.messages.created_with is None
     assert fake.messages.streamed_with["max_tokens"] == 32000
+
+
+def test_stepwise_uses_provided_turns():
+    """Prebuilt turns (with overrides applied) are what the API actually receives."""
+    c = _client("claude-sonnet-5")
+    turns = [
+        {"content": "STEP 1 - TUNED FIRST", "mcp": False},
+        {"content": "STEP 2 - TUNED SECOND", "mcp": False},
+    ]
+    seen = []
+
+    def fake_endpoint(*, system_prompt, messages, max_tokens, max_retries):
+        seen.append([m["content"] for m in messages if m["role"] == "user"])
+        return _response("end_turn", texts=('{"cluster_id": "1"}',)), 0.1
+
+    with patch.object(c, "_call_messages_endpoint", side_effect=fake_endpoint):
+        parsed, raw = c._analyze_stepwise(
+            system_prompt="sys", user_prompt="bundle", mcp=False, max_retries=1, turns=turns
+        )
+    assert "TUNED FIRST" in seen[0][0]
+    assert any("TUNED SECOND" in u for u in seen[-1])
+    assert len(raw["steps"]) == 2
+
+
+def test_analyze_rejects_turns_outside_stepwise():
+    c = _client("claude-sonnet-5")
+    with pytest.raises(ValueError, match="stepwise_turns"):
+        c.analyze(
+            system_prompt="sys",
+            user_prompt="u",
+            mode="cot",
+            stepwise_turns=[{"content": "x", "mcp": False}],
+        )
+
+
+def test_stepwise_truncation_labeled_not_parse_failure():
+    """A max_tokens stop with unparseable text is reported as truncation."""
+    c = _client("claude-sonnet-5")
+
+    def fake_endpoint(*, system_prompt, messages, max_tokens, max_retries):
+        return _response("max_tokens", texts=('{"cluster_id": ',)), 0.1
+
+    turns = [{"content": "STEP 1 - only step", "mcp": False}]
+    with patch.object(c, "_call_messages_endpoint", side_effect=fake_endpoint):
+        parsed, raw = c._analyze_stepwise(
+            system_prompt="sys", user_prompt="bundle", mcp=False, max_retries=1, turns=turns
+        )
+    assert raw["error"] == "output truncated at max_tokens"
+    assert raw["steps"][0]["stop_reason"] == "max_tokens"

--- a/tests/test_llm_api_clients.py
+++ b/tests/test_llm_api_clients.py
@@ -236,3 +236,50 @@ def test_stepwise_truncation_labeled_not_parse_failure():
         )
     assert raw["error"] == "output truncated at max_tokens"
     assert raw["steps"][0]["stop_reason"] == "max_tokens"
+
+
+# ---------------------------------------------------------------------------
+# Provider-generic analyze (OpenAI / Gemini path)
+# ---------------------------------------------------------------------------
+
+_VALID_JSON = """{"cluster_id": "1", "dominant_process": "proteasome", "pathway_confidence": "High",
+"established_genes": ["PSMA1"], "novel_role_genes": [], "uncharacterized_genes": []}"""
+
+
+def _generic_client(response_text=_VALID_JSON, fail=False):
+    from mozzarellm.clients.llm_api_clients import OpenAIClient
+
+    class _Stub(OpenAIClient):
+        def _make_api_call(self, system_prompt, user_prompt):
+            if fail:
+                raise RuntimeError("provider down")
+            self._last_usage = {"input_tokens": 100, "output_tokens": 50}
+            return response_text
+
+    return _Stub("gpt-test", 0.2, 1000, None, None, None, "test-key")
+
+
+def test_generic_analyze_parses_and_reports_usage():
+    parsed, raw = _generic_client().analyze(system_prompt="s", user_prompt="u", mode="cot")
+    assert parsed["dominant_process"] == "proteasome"
+    assert raw["input_tokens"] == 100 and raw["output_tokens"] == 50
+    assert raw["cost_usd"] is not None and raw["pricing_warning"]  # unknown model -> warned
+    assert raw["error"] is None
+
+
+def test_generic_analyze_rejects_anthropic_only_features():
+    import pytest
+
+    client = _generic_client()
+    with pytest.raises(ValueError, match="Anthropic-only"):
+        client.analyze(system_prompt="s", user_prompt="u", mcp=True)
+    with pytest.raises(ValueError, match="stepwise is Anthropic-only"):
+        client.analyze(system_prompt="s", user_prompt="u", mode="stepwise")
+
+
+def test_generic_analyze_surfaces_provider_errors():
+    parsed, raw = _generic_client(fail=True).analyze(
+        system_prompt="s", user_prompt="u", max_retries=1
+    )
+    assert parsed is None
+    assert "provider down" in raw["error"]


### PR DESCRIPTION
`analyze()` lived only on AnthropicClient — OpenAI/Gemini clients couldn't be driven by the pipeline at all. The base class now covers the single-call standard/cot path with the uniform (parsed, raw_outputs) contract; MCP/stepwise/batch stay Anthropic-only with clear rejections. Live smoke: `gemini-flash-latest` parses end-to-end; OpenAI authenticates but the account has no credits (429) — end-to-end OpenAI check awaits a funded key. 3 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZM4Pv2WDXKpuVcw9pdwrr