### PR TITLE
core: stepwise turns reach the client; truncation labeled honestly

### DIFF
--- a/benchmarks/workflow/bench_orchestrator.py
+++ b/benchmarks/workflow/bench_orchestrator.py
@@ -391,11 +391,13 @@ def execute_single_run(
         raw_outputs = generate_mock_raw_outputs(route)
     else:
         try:
+            stepwise_turns = prompts["stepwise_turns"]
             parsed, raw_outputs = client.analyze(
                 system_prompt=system_prompt,
                 user_prompt=user_prompt,
                 mode=route.mode,
                 mcp=route.mcp,
+                **({"stepwise_turns": stepwise_turns} if stepwise_turns is not None else {}),
             )
             error = raw_outputs.get("error")
         except Exception as e:

--- a/mozzarellm/clients/llm_api_clients.py
+++ b/mozzarellm/clients/llm_api_clients.py
@@ -599,6 +599,7 @@ class AnthropicClient(LLMClientBase):
         max_retries: int = 3,
         include_features: bool = False,
         source: str = "both",
+        stepwise_turns: list[dict] | None = None,
     ) -> tuple[dict | None, dict]:
         """Single entry point for cluster analysis.
 
@@ -624,6 +625,8 @@ class AnthropicClient(LLMClientBase):
         """
         if mode not in ("standard", "cot", "stepwise"):
             raise ValueError(f"mode must be one of 'standard', 'cot', 'stepwise'; got {mode!r}")
+        if stepwise_turns is not None and mode != "stepwise":
+            raise ValueError("stepwise_turns is only valid with mode='stepwise'")
         if batch and (mcp or mode == "stepwise"):
             raise ValueError(
                 "batch=True is incompatible with mcp=True or mode='stepwise' "
@@ -651,6 +654,7 @@ class AnthropicClient(LLMClientBase):
                 user_prompt=user_prompt,
                 mcp=mcp,
                 max_retries=max_retries,
+                turns=stepwise_turns,
             )
 
         if mcp:
@@ -777,6 +781,7 @@ class AnthropicClient(LLMClientBase):
             self.model, response.usage.input_tokens, response.usage.output_tokens
         )
 
+        stop_reason = getattr(response, "stop_reason", None)
         raw_outputs = self._empty_raw_outputs()
         raw_outputs.update(
             {
@@ -787,6 +792,7 @@ class AnthropicClient(LLMClientBase):
                 "elapsed_s": elapsed,
                 "cost_usd": cost,
                 "pricing_warning": pricing_warning,
+                "stop_reason": stop_reason,
             }
         )
 
@@ -798,13 +804,20 @@ class AnthropicClient(LLMClientBase):
             "cost_usd": cost,
             "time_seconds": round(elapsed, 1),
             "tool_calls": len(tool_calls),
+            "stop_reason": stop_reason,
         }
         if pricing_warning:
             meta["pricing_warning"] = pricing_warning
 
         if not parsed:
-            meta_err = {**meta, "error": "failed to parse JSON", "raw_output": output_text[:1000]}
-            raw_outputs["error"] = "failed to parse JSON"
+            # A max_tokens stop with no (or partial) text is a truncation, not a
+            # parsing defect -- label it so failure accounting can tell them apart.
+            if stop_reason == "max_tokens":
+                error = "output truncated at max_tokens" + (" (no text)" if not output_text else "")
+            else:
+                error = "failed to parse JSON"
+            meta_err = {**meta, "error": error, "raw_output": output_text[:1000]}
+            raw_outputs["error"] = error
             return ({"_validation_metadata": meta_err}, raw_outputs)
 
         schema_warnings = _validate_literature_blocks(parsed)
@@ -857,12 +870,17 @@ class AnthropicClient(LLMClientBase):
         mcp: bool,
         max_retries: int,
         max_tokens: int = 16000,
+        turns: list[dict] | None = None,
     ) -> tuple[dict | None, dict]:
         """Run the canonical CoT chain as N sequential, multi-turn API calls.
 
         Each step is a separate API call; prior assistant responses are appended
         to `messages` so step N sees steps 1..N-1's outputs. Steps in the MCP
         index set get PubMed tools attached; others use the plain endpoint.
+
+        turns: prebuilt per-turn content ({"content", "mcp"} dicts, e.g. from
+        compose_stepwise_user_turns with component overrides applied); when
+        None, the canonical turn list is composed here.
 
         On any step failure, iteration aborts and a partial trace is returned
         with steps 1..N-1 preserved.
@@ -877,7 +895,8 @@ class AnthropicClient(LLMClientBase):
         from mozzarellm.utils.trace import extract_mcp_tool_calls
 
         # Per-turn user content + MCP routing decided by prompt_factory.
-        turns = compose_stepwise_user_turns(mcp)
+        if turns is None:
+            turns = compose_stepwise_user_turns(mcp)
 
         messages: list[dict] = []
         step_records: list[dict] = []
@@ -946,6 +965,7 @@ class AnthropicClient(LLMClientBase):
                     "output_tokens": out_tok,
                     "elapsed_s": round(elapsed, 2),
                     "cost_usd": cost,
+                    "stop_reason": getattr(response, "stop_reason", None),
                     "error": None,
                 }
             )
@@ -989,8 +1009,13 @@ class AnthropicClient(LLMClientBase):
             meta["pricing_warning"] = "; ".join(pricing_warnings)
 
         if not parsed:
-            meta_err = {**meta, "error": "failed to parse JSON", "raw_output": final_text[:1000]}
-            raw_outputs["error"] = "failed to parse JSON"
+            final_stop = step_records[-1].get("stop_reason") if step_records else None
+            if final_stop == "max_tokens":
+                error = "output truncated at max_tokens" + (" (no text)" if not final_text else "")
+            else:
+                error = "failed to parse JSON"
+            meta_err = {**meta, "error": error, "raw_output": final_text[:1000]}
+            raw_outputs["error"] = error
             return ({"_validation_metadata": meta_err}, raw_outputs)
 
         if mcp:

--- a/mozzarellm/pipeline/screen_analysis.py
+++ b/mozzarellm/pipeline/screen_analysis.py
@@ -22,6 +22,7 @@ from mozzarellm.utils.cluster_utils import build_cluster_id_to_bundle_path
 from mozzarellm.utils.io import load_table
 from mozzarellm.utils.llm_analysis_utils import save_cluster_analysis
 from mozzarellm.utils.prompt_factory import (
+    compose_stepwise_user_turns,
     make_cluster_analysis_system_prompt,
     make_single_cluster_analysis_user_prompt,
 )
@@ -166,6 +167,9 @@ def analyze_screen(
         component_order=(list(CANONICAL_FEATURE_INTERP_COT_ORDER) if include_features else None),
         component_overrides=component_overrides,
     )
+    stepwise_turns = (
+        compose_stepwise_user_turns(mcp, component_overrides) if mode == "stepwise" else None
+    )
 
     results: dict = {}
     errors: dict = {}
@@ -184,6 +188,7 @@ def analyze_screen(
                 user_prompt=user_prompt,
                 mode=mode,
                 mcp=mcp,
+                **({"stepwise_turns": stepwise_turns} if stepwise_turns is not None else {}),
             )
         except Exception as e:  # noqa: BLE001 -- one bad cluster must not kill the run
             errors[cluster_id] = str(e)

--- a/mozzarellm/utils/pricing.py
+++ b/mozzarellm/utils/pricing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 # (input_$_per_M_tokens, output_$_per_M_tokens)
 MODEL_PRICING: dict[str, tuple[float, float]] = {
+    "claude-sonnet-5": (3.0, 15.0),
     "claude-opus-4-7": (15.0, 75.0),
     "claude-opus-4-5": (15.0, 75.0),
     "claude-sonnet-4-6": (3.0, 15.0),

--- a/tests/test_llm_api_clients.py
+++ b/tests/test_llm_api_clients.py
@@ -187,3 +187,52 @@ def test_large_outputs_stream_and_return_the_final_message():
     assert client._create_message(fake, {"max_tokens": 32000}) == "streamed"
     assert fake.messages.created_with is None
     assert fake.messages.streamed_with["max_tokens"] == 32000
+
+
+def test_stepwise_uses_provided_turns():
+    """Prebuilt turns (with overrides applied) are what the API actually receives."""
+    c = _client("claude-sonnet-5")
+    turns = [
+        {"content": "STEP 1 - TUNED FIRST", "mcp": False},
+        {"content": "STEP 2 - TUNED SECOND", "mcp": False},
+    ]
+    seen = []
+
+    def fake_endpoint(*, system_prompt, messages, max_tokens, max_retries):
+        seen.append([m["content"] for m in messages if m["role"] == "user"])
+        return _response("end_turn", texts=('{"cluster_id": "1"}',)), 0.1
+
+    with patch.object(c, "_call_messages_endpoint", side_effect=fake_endpoint):
+        parsed, raw = c._analyze_stepwise(
+            system_prompt="sys", user_prompt="bundle", mcp=False, max_retries=1, turns=turns
+        )
+    assert "TUNED FIRST" in seen[0][0]
+    assert any("TUNED SECOND" in u for u in seen[-1])
+    assert len(raw["steps"]) == 2
+
+
+def test_analyze_rejects_turns_outside_stepwise():
+    c = _client("claude-sonnet-5")
+    with pytest.raises(ValueError, match="stepwise_turns"):
+        c.analyze(
+            system_prompt="sys",
+            user_prompt="u",
+            mode="cot",
+            stepwise_turns=[{"content": "x", "mcp": False}],
+        )
+
+
+def test_stepwise_truncation_labeled_not_parse_failure():
+    """A max_tokens stop with unparseable text is reported as truncation."""
+    c = _client("claude-sonnet-5")
+
+    def fake_endpoint(*, system_prompt, messages, max_tokens, max_retries):
+        return _response("max_tokens", texts=('{"cluster_id": ',)), 0.1
+
+    turns = [{"content": "STEP 1 - only step", "mcp": False}]
+    with patch.object(c, "_call_messages_endpoint", side_effect=fake_endpoint):
+        parsed, raw = c._analyze_stepwise(
+            system_prompt="sys", user_prompt="bundle", mcp=False, max_retries=1, turns=turns
+        )
+    assert raw["error"] == "output truncated at max_tokens"
+    assert raw["steps"][0]["stop_reason"] == "max_tokens"


### PR DESCRIPTION
Reviewer's guide: start at bench_orchestrator.py's client.analyze call and _analyze_stepwise's new `turns` parameter — that pair is the behavior fix; the stop_reason lines in _analyze_mcp/_analyze_stepwise are the honesty fix; pricing.py is one table row.

Found auditing before the mode rerun: the orchestrator composes stepwise turns with component overrides but only records them — client._analyze_stepwise recomposed canonical turns internally, so every stepwise run's prompts.jsonl differed from what actually ran (stepwise_litb executed stepwise_lit's prompts; analyze_screen's stepwise overrides were silently dropped). analyze() now accepts stepwise_turns (rejected outside mode='stepwise'); the orchestrator and analyze_screen pass prebuilt turns, conditionally so duck-typed provider clients are unaffected.

Second: MCP/stepwise paths never recorded stop_reason, so a max_tokens stop with no text block was logged as 'failed to parse JSON' — most of the mode run's 19 failures were these truncations (shuffled decoys burning the full budget in tool loops). Both paths now carry stop_reason in raw_outputs/steps and label truncations distinctly, so the failure column separates capacity from parsing.

Third: claude-sonnet-5 added to MODEL_PRICING at tier rates identical to the fallback previously used — no recorded cost changes, the per-trace unknown-model warning disappears.

Validated: 3 new tests (endpoint receives provided turns; guard; truncation label), suite 301 passing, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZM4Pv2WDXKpuVcw9pdwrr